### PR TITLE
Consume reticulum-kt from JitPack v0.0.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "reticulum-kt"]
-	path = reticulum-kt
-	url = ../reticulum-kt

--- a/lxmf-core/build.gradle.kts
+++ b/lxmf-core/build.gradle.kts
@@ -8,20 +8,19 @@ val kotestVersion: String by project
 
 dependencies {
     // Depend on rns-core for Reticulum functionality
-    implementation("network.reticulum:rns-core")
+    implementation("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.3")
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
     // Test dependencies for live networking tests
-    testImplementation("network.reticulum:rns-interfaces")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:v0.0.3")
 
     // MessagePack for serialization (already in rns-core, but explicit)
     implementation("org.msgpack:msgpack-core:0.9.8")
 
-    // Logging
+    // Logging — SLF4J API only; consumers supply their own binding
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
-    implementation("org.slf4j:slf4j-simple:2.0.9")
 
     // Testing
     testImplementation(kotlin("test"))
@@ -29,9 +28,10 @@ dependencies {
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+    testRuntimeOnly("org.slf4j:slf4j-simple:2.0.9")
 
     // Interop testing - reuse Python bridge infrastructure from rns-test
-    testImplementation("network.reticulum:rns-test")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:v0.0.3")
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
     // Compression - Apache Commons Compress for BZ2 interop tests

--- a/lxmf-examples/build.gradle.kts
+++ b/lxmf-examples/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 val coroutinesVersion: String by project
 
 dependencies {
-    implementation("network.reticulum:rns-core")
-    implementation("network.reticulum:rns-interfaces")
+    implementation("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.3")
+    implementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:v0.0.3")
     implementation(project(":lxmf-core"))
 
     // Coroutines

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 
@@ -18,5 +19,3 @@ rootProject.name = "lxmf-kt"
 
 include(":lxmf-core")
 include(":lxmf-examples")
-
-includeBuild("reticulum-kt")


### PR DESCRIPTION
## Summary
Replaces the composite-build + git-submodule wiring for reticulum-kt with pinned JitPack coordinates. After this lxmf-kt builds standalone without needing a local reticulum-kt checkout, and the nested submodule goes away.

## Coordinate changes
| From | To |
|---|---|
| `network.reticulum:rns-core` (composite) | `com.github.torlando-tech.reticulum-kt:rns-core:v0.0.3` |
| `network.reticulum:rns-interfaces` (composite) | `com.github.torlando-tech.reticulum-kt:rns-interfaces:v0.0.3` |
| `network.reticulum:rns-test` (composite) | `com.github.torlando-tech.reticulum-kt:rns-test:v0.0.3` |

Applied in both `lxmf-core` and `lxmf-examples`.

## SLF4J scoping
- `lxmf-core`: moved `slf4j-simple` from `implementation` to `testRuntimeOnly`. Libraries should ship `slf4j-api` only (via `kotlin-logging-jvm`) and let consuming apps choose their binding. Tests keep the binding for log output.
- `lxmf-examples`: kept `slf4j-simple` as `implementation` — this module produces a runnable shadowJar, not a library.

## Submodule removal
The nested `reticulum-kt/` submodule is removed along with `.gitmodules`. Its purpose was to satisfy `includeBuild("reticulum-kt")`, which this PR also removes.

## Test plan
- [x] `./gradlew --refresh-dependencies :lxmf-core:compileKotlin :lxmf-core:compileTestKotlin :lxmf-examples:compileKotlin` succeeds
- [x] rns-test base classes (RnsLiveTestBase etc.) compile against the published artifact
- [ ] Full test suite in CI with `PYTHON_RNS_PATH` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)