### PR TITLE
Scope rns-core as api so consumers get it on compile classpath

### DIFF
--- a/lxmf-core/build.gradle.kts
+++ b/lxmf-core/build.gradle.kts
@@ -16,8 +16,11 @@ val junitVersion: String by project
 val kotestVersion: String by project
 
 dependencies {
-    // Depend on rns-core for Reticulum functionality
-    implementation("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.3")
+    // Depend on rns-core for Reticulum functionality.
+    // api scope: lxmf-core's public API (LXMRouter, LXMessage) exposes
+    // rns-core types (Destination, Identity) as parameters and return types,
+    // so consumers need rns-core on their compile classpath.
+    api("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.3")
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")


### PR DESCRIPTION
## Summary
Changes `lxmf-core`'s rns-core dep from `implementation` to `api`. The published v0.0.2 POM scopes rns-core as `runtime`, which would break any downstream consumer that references `Destination`/`Identity` types from lxmf-core's public API.

## Why
lxmf-core's public API surfaces rns-core types in several places:
- `LXMRouter.DeliveryDestination.destination: Destination`
- `LXMRouter.DeliveryDestination.identity: Identity`
- `LXMRouter.getDeliveryDestination(hexHash: String): DeliveryDestination?`
- `LXMRouter.identityAllowed(identity: Identity): Boolean`
- `LXMessage.destination: Destination?`, `LXMessage.source: Destination?`

Gradle's `implementation` scope maps to Maven's `runtime` scope in published POMs. Downstream consumers importing lxmf-core would find these types unresolvable at compile time. Same scoping fix as rns-interfaces → rns-core (`api(project(":rns-core"))`) applied earlier in reticulum-kt.

## Test plan
- [x] `VERSION=0.0.3 ./gradlew :lxmf-core:publishToMavenLocal` succeeds
- [x] Published POM lists `rns-core` at `<scope>compile</scope>` (was `runtime` in v0.0.2)
- [ ] After merge + tag `v0.0.3`: columba can consume lxmf-core and reference rns-core types via transitive resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)