### PR TITLE
Release pendingOutboundMutex before per-message delivery dispatch

### DIFF
--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -97,6 +97,15 @@ class LXMRouter(
     }
 
     // ===== Message Queues =====
+    //
+    // Lock ordering (to avoid deadlock on any future nested acquisition):
+    //   pendingOutboundMutex  →  failedOutboundMutex
+    //
+    // Today the only nested site is inside [processOutbound] where a
+    // FAILED-state message is moved from pendingOutbound to failedOutbound.
+    // The reverse order is never acquired. Any new code that needs both
+    // mutexes MUST follow this order, or restructure to take them
+    // independently.
 
     /** Pending inbound messages awaiting processing */
     private val pendingInbound = mutableListOf<LXMessage>()
@@ -578,6 +587,18 @@ class LXMRouter(
             // queue mutex across these calls — as this method used to — would
             // wedge every handleOutbound caller behind whatever interface
             // blocks longest.
+            //
+            // Intra-batch ordering is intentionally sequential: messages
+            // snapshotted into toDispatch in one processOutbound() call are
+            // dispatched in FIFO order, one after the other, under the
+            // outboundProcessingMutex guard. This means a slow send for the
+            // first message still delays the second message in the same
+            // batch — but this no longer blocks unrelated handleOutbound
+            // callers (which was the bug this PR fixes). Parallelising
+            // intra-batch dispatch (e.g. launching per-message coroutines)
+            // is a possible future optimisation; it is deliberately not done
+            // here to keep the fix minimal and preserve the existing
+            // delivery-ordering contract.
             for (message in toDispatch) {
                 processOutboundMessage(message)
             }

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -517,8 +517,16 @@ class LXMRouter(
 
         try {
             val toRemove = mutableListOf<LXMessage>()
+            val toDispatch = mutableListOf<LXMessage>()
+            val toFailCallback = mutableListOf<LXMessage>()
             val currentTime = System.currentTimeMillis()
 
+            // Classify current pendingOutbound under the queue lock. Do NOT
+            // invoke user callbacks or per-message delivery dispatch here —
+            // those can suspend on network I/O (packet.send over a flaky
+            // interface) and would wedge every concurrent handleOutbound
+            // caller on this same mutex. See LXMRouterTest
+            // "handleOutbound not blocked when processOutboundMessage hangs".
             pendingOutboundMutex.withLock {
                 for (message in pendingOutbound) {
                     when (message.state) {
@@ -535,7 +543,7 @@ class LXMRouter(
 
                         MessageState.CANCELLED, MessageState.REJECTED -> {
                             toRemove.add(message)
-                            failedDeliveryCallback?.invoke(message)
+                            toFailCallback.add(message)
                         }
 
                         MessageState.FAILED -> {
@@ -543,14 +551,15 @@ class LXMRouter(
                             failedOutboundMutex.withLock {
                                 failedOutbound.add(message)
                             }
-                            failedDeliveryCallback?.invoke(message)
+                            toFailCallback.add(message)
                         }
 
                         MessageState.OUTBOUND -> {
-                            // Check if ready to attempt delivery
+                            // Check if ready to attempt delivery. The actual
+                            // dispatch happens AFTER we release the lock.
                             val nextAttempt = message.nextDeliveryAttempt ?: 0L
                             if (currentTime >= nextAttempt) {
-                                processOutboundMessage(message)
+                                toDispatch.add(message)
                             }
                         }
 
@@ -563,15 +572,47 @@ class LXMRouter(
                 // Remove processed messages
                 pendingOutbound.removeAll(toRemove)
             }
+
+            // Dispatch per-message delivery OUTSIDE the queue lock. This is
+            // where the real work (and any blocking I/O) happens. Holding the
+            // queue mutex across these calls — as this method used to — would
+            // wedge every handleOutbound caller behind whatever interface
+            // blocks longest.
+            for (message in toDispatch) {
+                processOutboundMessage(message)
+            }
+
+            // User callbacks for terminal-state messages also run outside
+            // the lock — same rationale. A slow or misbehaving callback
+            // shouldn't block unrelated sends from being queued.
+            val failedCb = failedDeliveryCallback
+            if (failedCb != null) {
+                for (message in toFailCallback) {
+                    failedCb.invoke(message)
+                }
+            }
         } finally {
             outboundProcessingMutex.unlock()
         }
     }
 
     /**
+     * Test-only hook fired at the start of [processOutboundMessage]. Exists
+     * so a regression test for "mutex held across per-message dispatch" can
+     * simulate a slow / hung delivery by suspending in this hook; any
+     * coroutine trying to take [pendingOutboundMutex] concurrently reveals
+     * whether the mutex is still held while the hook is in-flight. Production
+     * code MUST NOT install this.
+     */
+    @org.jetbrains.annotations.VisibleForTesting
+    internal var testHookOnProcessOutboundMessage: (suspend (LXMessage) -> Unit)? = null
+
+    /**
      * Process a single outbound message based on its delivery method.
      */
     private suspend fun processOutboundMessage(message: LXMessage) {
+        testHookOnProcessOutboundMessage?.invoke(message)
+
         val method = message.desiredMethod ?: DeliveryMethod.DIRECT
 
         when (method) {

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
@@ -872,22 +872,32 @@ class LXMRouterTest {
             )
         }
 
-        // 1. Queue one message that will be picked up by processOutbound.
-        val firstMessage = buildOutboundMessage(destIdentity1)
-        firstMessage.nextDeliveryAttempt = 0L // ready for dispatch now
-        router.handleOutbound(firstMessage)
-        assertEquals(1, router.pendingOutboundCount())
-
-        // 2. Install the test hook so processOutboundMessage suspends
-        // indefinitely (until we release it). Pre-fix this suspension
-        // happens INSIDE pendingOutboundMutex.withLock, so any concurrent
-        // handleOutbound call is wedged on the same mutex.
+        // 1. Install the test hook FIRST, before any message is queued.
+        // processOutboundMessage suspends indefinitely inside the hook
+        // until we release it. Pre-fix this suspension happens INSIDE
+        // pendingOutboundMutex.withLock, so any concurrent handleOutbound
+        // call is wedged on the same mutex.
+        //
+        // Install-before-queue ordering matters: handleOutbound calls
+        // triggerProcessing(), which would launch processOutbound on
+        // processingScope's Dispatchers.IO if router.start() had been
+        // called. Today start() is not called in this test so
+        // triggerProcessing is a no-op, but installing the hook first
+        // makes the test robust to future changes (e.g. if start() is
+        // added to @BeforeEach) and eliminates any reader's doubt about
+        // a scope-launch-vs-hook-install race.
         val hookEntered = CompletableDeferred<Unit>()
         val hookRelease = CompletableDeferred<Unit>()
         router.testHookOnProcessOutboundMessage = {
             hookEntered.complete(Unit)
             hookRelease.await()
         }
+
+        // 2. Queue one message that will be picked up by processOutbound.
+        val firstMessage = buildOutboundMessage(destIdentity1)
+        firstMessage.nextDeliveryAttempt = 0L // ready for dispatch now
+        router.handleOutbound(firstMessage)
+        assertEquals(1, router.pendingOutboundCount())
 
         // 3. Launch processOutbound in a separate coroutine. It will
         // call processOutboundMessage (hitting our hook) and suspend.

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
@@ -1,6 +1,10 @@
 package network.reticulum.lxmf
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import network.reticulum.common.DestinationDirection
 import network.reticulum.common.DestinationType
 import network.reticulum.destination.Destination
@@ -815,6 +819,104 @@ class LXMRouterTest {
         // hops is a non-nullable Int on Packet (defaults to 0 / user-set 2
         // here), so it WILL propagate — that's correct.
         assertEquals(2, delivered.receivedHopCount)
+    }
+
+    /**
+     * Regression test for the send-spinner-hang observed on 2026-04-20.
+     *
+     * Symptom: two Columba phones messaging each other; after disabling
+     * interfaces on one phone mid-send, subsequent sends hang forever with
+     * the UI spinner never clearing. On-device instrumentation narrowed
+     * the wedge to [LXMRouter.handleOutbound] blocking at
+     * `pendingOutboundMutex.withLock`, waiting on a lock held by a prior
+     * [processOutbound] call that was stuck inside [processOutboundMessage]
+     * (synchronous `packet.send()` blocking on a flaky/disabled interface).
+     *
+     * Root cause: [processOutbound] held [pendingOutboundMutex] across
+     * every per-message delivery dispatch. A single hung delivery wedged
+     * every subsequent [handleOutbound] caller on the same mutex.
+     *
+     * Invariant this test pins: `handleOutbound` must not block on a
+     * long-running [processOutboundMessage] call. Concretely, the lock
+     * must be released BEFORE the per-message dispatch runs.
+     *
+     * Pre-fix behaviour: the `withTimeout(400)` below trips because
+     * `handleOutbound` suspends on the mutex held by the wedged hook.
+     * Post-fix behaviour: `handleOutbound` completes within a few ms.
+     */
+    @Test
+    fun `handleOutbound not blocked when processOutboundMessage hangs (regression)`() = runBlocking {
+        val destIdentity1 = Identity.create()
+        val destIdentity2 = Identity.create()
+        val sourceDestination = Destination.create(
+            identity = identity,
+            direction = DestinationDirection.IN,
+            type = DestinationType.SINGLE,
+            appName = "lxmf",
+            "delivery"
+        )
+
+        fun buildOutboundMessage(destIdentity: Identity): LXMessage {
+            val destDestination = Destination.create(
+                identity = destIdentity,
+                direction = DestinationDirection.OUT,
+                type = DestinationType.SINGLE,
+                appName = "lxmf",
+                "delivery"
+            )
+            return LXMessage.create(
+                destination = destDestination,
+                source = sourceDestination,
+                content = "test",
+                title = "test"
+            )
+        }
+
+        // 1. Queue one message that will be picked up by processOutbound.
+        val firstMessage = buildOutboundMessage(destIdentity1)
+        firstMessage.nextDeliveryAttempt = 0L // ready for dispatch now
+        router.handleOutbound(firstMessage)
+        assertEquals(1, router.pendingOutboundCount())
+
+        // 2. Install the test hook so processOutboundMessage suspends
+        // indefinitely (until we release it). Pre-fix this suspension
+        // happens INSIDE pendingOutboundMutex.withLock, so any concurrent
+        // handleOutbound call is wedged on the same mutex.
+        val hookEntered = CompletableDeferred<Unit>()
+        val hookRelease = CompletableDeferred<Unit>()
+        router.testHookOnProcessOutboundMessage = {
+            hookEntered.complete(Unit)
+            hookRelease.await()
+        }
+
+        // 3. Launch processOutbound in a separate coroutine. It will
+        // call processOutboundMessage (hitting our hook) and suspend.
+        val processJob = launch(Dispatchers.Default) { router.processOutbound() }
+
+        try {
+            // 4. Wait until the hook has been entered — at this point,
+            // processOutbound is suspended inside processOutboundMessage.
+            // The question under test: is pendingOutboundMutex still held?
+            hookEntered.await()
+
+            // 5. Call handleOutbound from the test coroutine. If the
+            // mutex is held across the hook (bug), this suspends until
+            // the timeout trips. Post-fix, the mutex has already been
+            // released, so this returns in a few ms.
+            withTimeout(400) {
+                router.handleOutbound(buildOutboundMessage(destIdentity2))
+            }
+
+            assertEquals(
+                2,
+                router.pendingOutboundCount(),
+                "Second message should be queued while processOutbound is mid-dispatch"
+            )
+        } finally {
+            hookRelease.complete(Unit)
+            router.testHookOnProcessOutboundMessage = null
+            processJob.join()
+        }
     }
 
     // Make propagationTransferState accessible for tests


### PR DESCRIPTION
## Summary

Closes a coroutine-mutex deadlock where a single stuck opportunistic send in `processOutboundMessage` wedged every subsequent `handleOutbound` caller for the life of the LXMRouter. This was the root cause of a send-spinner-hang reproduced on-device on 2026-04-20 in Columba, confirmed via instrumentation.

## Root cause

`processOutbound` held `pendingOutboundMutex` across the entire per-message delivery dispatch:

```kotlin
pendingOutboundMutex.withLock {
    for (message in pendingOutbound) {
        when (message.state) {
            MessageState.OUTBOUND -> processOutboundMessage(message)  // <-- under lock
            ...
        }
    }
}
```

`processOutboundMessage` → `processOpportunisticDelivery` → `sendOpportunisticMessage` → `packet.send()` → `Transport.outbound()` → `interface.processOutgoing(data)`. That bottom layer is a **synchronous** interface write. When any interface blocks — e.g. a TCP interface just disabled on the peer side, an RNode mid-USB-hiccup, BLE mid-GATT-renegotiation — the queue mutex is held for the duration. Every concurrent `handleOutbound` caller then suspends indefinitely at `pendingOutboundMutex.withLock { pendingOutbound.add(message) }`.

On-device repro log from .249 showing the wedge:

```
handleOutbound ENTER (thread 12707) → mutex-acquired → post-mutex → EXIT ✓
handleOutbound ENTER (thread 12693) → pre-mutex → <silence — wedged here>
handleOutbound ENTER (thread 12679) → pre-mutex → <silence — wedged here>
```

## The fix

Classify messages under the lock (cheap, bounded), dispatch outside. Same for `failedDeliveryCallback` — user callbacks shouldn't hold the queue mutex either.

## Test

Added regression test `handleOutbound not blocked when processOutboundMessage hangs` which uses a narrow internal test hook (`testHookOnProcessOutboundMessage`) to suspend indefinitely at the start of `processOutboundMessage`. Assertion: a concurrent `handleOutbound` on a different message must complete within 400ms.

- **Pre-fix**: `TimeoutCancellationException` — `handleOutbound` wedged on the held mutex
- **Post-fix**: test passes in ~5ms

All 24 existing `LXMRouterTest` cases remain green. Interop tests require a Python RNS environment and weren't affected.

## Test plan

- [x] `:lxmf-core:test --tests LXMRouterTest` — 24/24 pass
- [x] New regression test FAILS against main, PASSES against this PR
- [ ] Downstream verification: rebuild Columba against this branch, reproduce the 2026-04-20 multi-interface routing scenario, confirm send-spinner-hang no longer manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)