### PR TITLE
Add unit-tests CI workflow + opt-in interop exclusion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+# Runs the lxmf-core unit tests on every PR so regressions land-gated
+# instead of relying on author-local validation. The interop subpackage
+# (`network.reticulum.lxmf.interop.*`) is excluded by default — those
+# tests spawn a Python bridge subprocess that isn't available in the
+# default runner environment. Opt in with `-PrunInteropTests=true` from
+# a workflow that has prepared the bridge.
+#
+# Motivated by LXMF-kt#11 which added a concurrency regression test;
+# without CI, that test is just checked-in documentation of an
+# invariant rather than an enforced guarantee.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run lxmf-core unit tests (excluding interop)
+        run: ./gradlew :lxmf-core:test --no-daemon
+
+      - name: Upload test report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: lxmf-core/build/reports/tests/test/
+          retention-days: 14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 # Runs the lxmf-core unit tests on every PR so regressions land-gated
 # instead of relying on author-local validation. The interop subpackage
-# (`network.reticulum.lxmf.interop.*`) is excluded by default — those
+# (`network.reticulum.lxmf.interop.**`) is excluded by default — those
 # tests spawn a Python bridge subprocess that isn't available in the
 # default runner environment. Opt in with `-PrunInteropTests=true` from
 # a workflow that has prepared the bridge.
@@ -21,25 +21,27 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.1
 
       - name: Run lxmf-core unit tests (excluding interop)
         run: ./gradlew :lxmf-core:test --no-daemon
 
       - name: Upload test report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-report
           path: lxmf-core/build/reports/tests/test/

--- a/lxmf-core/build.gradle.kts
+++ b/lxmf-core/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
 tasks.named<Test>("test") {
     if (project.findProperty("runInteropTests") != "true") {
         filter {
-            excludeTestsMatching("network.reticulum.lxmf.interop.*")
+            excludeTestsMatching("network.reticulum.lxmf.interop.**")
         }
     }
 }

--- a/lxmf-core/build.gradle.kts
+++ b/lxmf-core/build.gradle.kts
@@ -49,3 +49,17 @@ dependencies {
     // Compression - Apache Commons Compress for BZ2 interop tests
     testImplementation("org.apache.commons:commons-compress:1.26.0")
 }
+
+// Exclude the `interop` test suite from the default `test` task. These tests
+// spawn a Python bridge subprocess from `python-bridge/bridge_server.py`
+// (provided out-of-band via the rns-test dependency's setup scripts) and fail
+// in any environment where that bridge isn't available — including default
+// GitHub Actions runners. Opt in with `-PrunInteropTests=true` locally when
+// the Python-side setup is prepared.
+tasks.named<Test>("test") {
+    if (project.findProperty("runInteropTests") != "true") {
+        filter {
+            excludeTestsMatching("network.reticulum.lxmf.interop.*")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

LXMF-kt had no CI. Regression tests — including the one added in #11 for the `pendingOutboundMutex` deadlock — were checked-in documentation of intent rather than enforced guarantees. Same class of gap that bit `reticulum-conformance` earlier today and caused the `test_bz2_compress` / `test_path_response_reuses_cached_announce` silent masks.

## What lands

1. `.github/workflows/tests.yml` — runs `:lxmf-core:test` on every PR and push to main on ubuntu-latest with JDK 21 (Temurin) via `gradle/actions/setup-gradle@v4`. Uploads `lxmf-core/build/reports/tests/test/` as an artifact on failure for debugging.
2. Gradle filter in `lxmf-core/build.gradle.kts` excluding `network.reticulum.lxmf.interop.*` by default. The interop suite spawns a Python bridge subprocess (`python-bridge/bridge_server.py`) that isn't in this repo and fails with `IllegalStateException: Bridge script not found` as-is. Contributors with the Python side prepared can opt in with `-PrunInteropTests=true`.

## Verification

- `./gradlew :lxmf-core:test --rerun-tasks` locally: **74 tests across 5 classes, all green** (LXMRouterTest, LXMessageTest, LXMessageInteropTest, LXStamperTest, PropagationSyncTest — the middle "InteropTest" one confusingly lives outside the interop sub-package and doesn't need the bridge).
- `-PrunInteropTests=true` keeps the interop suite running for local dev; default CI run excludes them.

## Why now

Downstream PR #11 fixes a real coroutine deadlock with a regression test. Without CI, nothing runs that test except my laptop. Adding this workflow upgrades the test from documentation to enforcement. Apply and land in parallel with #11 so `main` is CI-gated immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)