### PR TITLE
Make processingScope process-lifetime to prevent silent-drop after stop()

### DIFF
--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -184,7 +184,29 @@ class LXMRouter(
     private var running = false
 
     /** Coroutine scope for background processing */
-    private var processingScope: CoroutineScope? = null
+    /**
+     * Process-lifetime scope for outbound dispatch + deferred-stamp + cache
+     * cleanup work. Previously this was `var processingScope: CoroutineScope?`
+     * assigned in [start] and cancelled+nulled in [stop]; [triggerProcessing]
+     * and a dozen other call sites used `processingScope.launch { ... }`,
+     * which silently no-op'd whenever the scope was null. That created a
+     * latent silent-drop hazard: any lifecycle transition that called [stop]
+     * without [start] being re-called left `handleOutbound` silently
+     * enqueueing messages that no coroutine would ever dispatch — messages
+     * "stuck pending" forever in downstream consumer UIs. Reproduced on a
+     * Columba device on 2026-04-21 after a Doze cycle.
+     *
+     * The scope is now owned by the router for its entire object lifetime
+     * and is never null. [start] / [stop] gate the PERIODIC processing
+     * loop (via the [running] flag and [processingJob]), not the scope
+     * itself; one-shot launches from [triggerProcessing] and its peers
+     * succeed whether or not [start] has been called. This matches the
+     * structural fix pattern from reticulum-kt PR #818
+     * (NativeInterfaceFactory) — give the class its own non-null val
+     * scope, never let a child-cancellable reference back at it.
+     */
+    private val processingScope: CoroutineScope =
+        CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     /** Processing job */
     private var processingJob: Job? = null
@@ -509,7 +531,7 @@ class LXMRouter(
      * Trigger outbound processing.
      */
     private fun triggerProcessing() {
-        processingScope?.launch {
+        processingScope.launch {
             processOutbound()
         }
     }
@@ -701,7 +723,7 @@ class LXMRouter(
                 // Drop existing path and re-request (Python does this via Reticulum.drop_path + request_path)
                 Transport.expirePath(dest.hash)
                 // Small delay then request new path (matching Python's 0.5s sleep in thread)
-                processingScope?.launch {
+                processingScope.launch {
                     delay(500)
                     Transport.requestPath(dest.hash)
                 }
@@ -993,7 +1015,7 @@ class LXMRouter(
      * Handle a link being closed.
      */
     private fun handleLinkClosed(destHashHex: String) {
-        processingScope?.launch {
+        processingScope.launch {
             pendingOutboundMutex.withLock {
                 for (message in pendingOutbound) {
                     if (message.destinationHash.toHexString() == destHashHex &&
@@ -1630,7 +1652,7 @@ class LXMRouter(
 
         // Trigger retry for pending messages to this destination
         val destHashHex = destHash.toHexString()
-        processingScope?.launch {
+        processingScope.launch {
             pendingOutboundMutex.withLock {
                 for (message in pendingOutbound) {
                     if (message.destinationHash.toHexString() == destHashHex) {
@@ -1654,10 +1676,11 @@ class LXMRouter(
         loadPropagationNodes()
 
         running = true
-        processingScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
+        // processingScope is now process-lifetime (constructed at router init);
+        // start() no longer assigns it. The periodic loop below is still gated
+        // by the `running` flag and tracked via processingJob for cancellation.
         processingJob =
-            processingScope?.launch {
+            processingScope.launch {
                 while (running) {
                     try {
                         processOutbound()
@@ -1683,9 +1706,13 @@ class LXMRouter(
      */
     fun stop() {
         running = false
+        // Cancel the periodic processing loop — but NOT the scope itself.
+        // Keeping processingScope alive across stop() means a subsequent
+        // handleOutbound() call will still dispatch via triggerProcessing,
+        // instead of silently enqueueing a message with no coroutine to
+        // ever run it. See the processingScope KDoc for the 2026-04-21
+        // silent-drop regression that motivated this change.
         processingJob?.cancel()
-        processingScope?.cancel()
-        processingScope = null
     }
 
     // ===== Utility Methods =====
@@ -2055,7 +2082,7 @@ class LXMRouter(
                             requestMessageList(establishedLink)
                         } else {
                             // Delivery path: re-trigger outbound processing for pending messages (Python line 2709)
-                            processingScope?.launch {
+                            processingScope.launch {
                                 // Reset nextDeliveryAttempt for pending PROPAGATED messages so they get processed immediately.
                                 // This matches Python's behavior where process_outbound sends immediately when link is active,
                                 // without checking next_delivery_attempt (which was set when we initiated link establishment).
@@ -2156,7 +2183,7 @@ class LXMRouter(
                 if (messageListRetryCount < MAX_MESSAGE_LIST_RETRIES) {
                     messageListRetryCount++
                     println("Propagation node returned error $errorCode, retrying ($messageListRetryCount/$MAX_MESSAGE_LIST_RETRIES)...")
-                    processingScope?.launch {
+                    processingScope.launch {
                         kotlinx.coroutines.delay(MESSAGE_LIST_RETRY_DELAY_MS * messageListRetryCount)
                         requestMessageList(link)
                     }
@@ -2523,7 +2550,7 @@ class LXMRouter(
     }
 
     private fun saveOutboundStampCostsAsync() {
-        processingScope?.launch {
+        processingScope.launch {
             costFileMutex.withLock { saveOutboundStampCosts() }
         }
     }
@@ -2628,7 +2655,7 @@ class LXMRouter(
     }
 
     private fun saveAvailableTicketsAsync() {
-        processingScope?.launch {
+        processingScope.launch {
             ticketFileMutex.withLock { saveAvailableTickets() }
         }
     }
@@ -2746,7 +2773,7 @@ class LXMRouter(
     }
 
     private fun saveTransientIdsAsync() {
-        processingScope?.launch {
+        processingScope.launch {
             transientIdFileMutex.withLock { saveTransientIds() }
         }
     }

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -42,7 +42,7 @@ class LXMRouter(
     private val storagePath: String? = null,
     /** Whether to automatically peer with propagation nodes */
     private val autopeer: Boolean = true,
-) {
+) : AutoCloseable {
     // ===== Configuration Constants =====
 
     companion object {
@@ -183,7 +183,6 @@ class LXMRouter(
     @Volatile
     private var running = false
 
-    /** Coroutine scope for background processing */
     /**
      * Process-lifetime scope for outbound dispatch + deferred-stamp + cache
      * cleanup work. Previously this was `var processingScope: CoroutineScope?`
@@ -204,6 +203,11 @@ class LXMRouter(
      * structural fix pattern from reticulum-kt PR #818
      * (NativeInterfaceFactory) — give the class its own non-null val
      * scope, never let a child-cancellable reference back at it.
+     *
+     * For non-singleton use (e.g. tests that create many routers, or a
+     * rebuild after a reticulum-subprocess restart), call [close] to
+     * release the scope — otherwise its [SupervisorJob] anchors any
+     * in-flight coroutines until the process exits.
      */
     private val processingScope: CoroutineScope =
         CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -1713,6 +1717,22 @@ class LXMRouter(
         // ever run it. See the processingScope KDoc for the 2026-04-21
         // silent-drop regression that motivated this change.
         processingJob?.cancel()
+    }
+
+    /**
+     * Release the router's [processingScope] and the periodic processing
+     * loop. Intended for non-singleton use — tests that create many routers,
+     * or any caller that rebuilds the router after a reticulum-subprocess
+     * restart. After [close] the router must not be reused; any call to
+     * [handleOutbound] or [triggerProcessing] will no-op silently because
+     * the scope's [SupervisorJob] has been cancelled.
+     *
+     * For singleton Android use the default [stop] is sufficient; calling
+     * [close] is optional.
+     */
+    override fun close() {
+        stop()
+        processingScope.cancel()
     }
 
     // ===== Utility Methods =====

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
@@ -929,6 +929,86 @@ class LXMRouterTest {
         }
     }
 
+    /**
+     * Regression test for the post-Doze messaging-wedge observed on
+     * 2026-04-21 on Columba phones. After a Doze cycle (`dumpsys
+     * deviceidle force-idle` + `unforce`), the LXMF router ended up with
+     * `processingScope == null`: messages queued via `handleOutbound`
+     * were never dispatched, UI showed "pending" forever.
+     *
+     * Root cause: `triggerProcessing()` is `processingScope?.launch { ... }`.
+     * If the scope is null (router never started, or stopped and not
+     * re-started), the launch is a silent no-op — messages accumulate
+     * in `pendingOutbound` with no dispatcher to run `processOutbound`.
+     * Classic silent-drop anti-pattern #1 from
+     * [memory/feedback-silent-drop-patterns.md].
+     *
+     * Invariant this test pins: once `start()` has been called — even
+     * if `stop()` is subsequently called (simulating the lifecycle gap
+     * after Android's low-memory killer or a Doze-related process
+     * teardown) — any subsequent `handleOutbound` call MUST either
+     * dispatch the message, surface an error loudly, or transition the
+     * message out of `OUTBOUND` state within a bounded time. Pre-fix:
+     * the test times out because nothing runs. Post-fix: the test
+     * passes because the process-lifetime scope dispatches even after
+     * stop().
+     */
+    @Test
+    fun `handleOutbound dispatches after start-then-stop (regression - processingScope silent drop)`() = runBlocking {
+        // Simulate the post-Doze lifecycle gap: router was started, then
+        // stopped — matching a Columba scenario where the reticulum
+        // subprocess lifecycle or Android process management takes the
+        // router down without a clean re-start.
+        router.start()
+        router.stop()
+
+        // Arrange: a one-shot probe that completes when processOutboundMessage
+        // is actually invoked on a message. If triggerProcessing silently
+        // drops, this deferred never completes and the test times out.
+        val dispatched = CompletableDeferred<Unit>()
+        router.testHookOnProcessOutboundMessage = { dispatched.complete(Unit) }
+
+        val destIdentity = Identity.create()
+        val sourceDestination = Destination.create(
+            identity = identity,
+            direction = DestinationDirection.IN,
+            type = DestinationType.SINGLE,
+            appName = "lxmf",
+            "delivery"
+        )
+        val destDestination = Destination.create(
+            identity = destIdentity,
+            direction = DestinationDirection.OUT,
+            type = DestinationType.SINGLE,
+            appName = "lxmf",
+            "delivery"
+        )
+        val message = LXMessage.create(
+            destination = destDestination,
+            source = sourceDestination,
+            content = "post-stop",
+            title = "post-stop",
+            desiredMethod = DeliveryMethod.OPPORTUNISTIC
+        )
+
+        try {
+            router.handleOutbound(message)
+            assertEquals(
+                1,
+                router.pendingOutboundCount(),
+                "Message should be queued in pendingOutbound after handleOutbound"
+            )
+
+            // Pre-fix: triggerProcessing silently drops; no dispatch; timeout.
+            // Post-fix: process-lifetime scope keeps dispatching; hook fires in ms.
+            withTimeout(1000) {
+                dispatched.await()
+            }
+        } finally {
+            router.testHookOnProcessOutboundMessage = null
+        }
+    }
+
     // Make propagationTransferState accessible for tests
     val LXMRouter.propagationTransferState: LXMRouter.PropagationTransferState
         get() = try {

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
@@ -35,7 +35,10 @@ class LXMRouterTest {
 
     @AfterEach
     fun teardown() {
-        router.stop()
+        // close() cancels processingScope in addition to stop(), so each
+        // per-test router releases its SupervisorJob instead of leaking one
+        // scope per test until GC.
+        router.close()
     }
 
     @Test

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/PropagationSyncTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/PropagationSyncTest.kt
@@ -80,7 +80,7 @@ class PropagationSyncTest {
             "Sync should not fail when node is in map and hash is set",
         )
 
-        router.stop()
+        router.close()
     }
 
     @Test
@@ -117,6 +117,6 @@ class PropagationSyncTest {
             "Should fail when no active node hash is set",
         )
 
-        router.stop()
+        router.close()
     }
 }


### PR DESCRIPTION
## Summary

Closes a latent silent-drop where `handleOutbound` accepts messages into `pendingOutbound` but nothing ever dispatches them when `stop()` had run without a matching `start()` on the same instance.

## Reproducer (2026-04-21, Columba on Android)

On a phone that had gone through a Doze-cycle (`dumpsys deviceidle force-idle` + `unforce`), subsequent sends showed this log pattern:

```
D MessagingViewModel: Sending LXMF message to 7733aec1... ✓
D NativeReticulumProtocol: [SEND-DIAG] handleOutbound returned ✓
D NativeReticulumProtocol: [SEND-DIAG] exit sendMessage SUCCESS ✓
<<< silence — no LXMRouter opportunistic dispatch logs >>>
```

A healthy send normally follows with `[LXMRouter] Opportunistic delivery attempt 1 for ...` / `sendOpportunisticMessage: ...` / `Sent opportunistic message to ...`. None appeared. Messages accumulated in `pendingOutbound` with zero dispatchers to run `processOutbound`, UI stuck on "pending".

## Root cause

`processingScope` was `var CoroutineScope? = null`. `start()` assigned a fresh scope; `stop()` cancelled and nulled it. Every callsite in LXMRouter used `processingScope?.launch { ... }` — a silent no-op when null. `triggerProcessing()` is invoked from `handleOutbound`, so any lifecycle state where `stop()` had run without a matching `start()` silently dropped every subsequent send.

Classic silent-drop anti-pattern #1: *scope?.launch on a nullable or cancelled external scope*. Same shape as the reticulum-kt `NativeInterfaceFactory` bug that PR #818 fixed (there, the scope was assigned externally and could go null between protocol cycles; here, the scope was owned internally but lifecycle-nulled in `stop()`).

## Fix

Make `processingScope` a process-lifetime `val` at router init with `CoroutineScope(Dispatchers.IO + SupervisorJob())`. Remove the assignment in `start()` and the cancel+null in `stop()`. Keep `processingJob` cancellation in `stop()` so the periodic loop does stop — the `running` flag still gates the loop body, preserving the existing start/stop semantics for the periodic work. One-shot `processingScope.launch { ... }` calls from `triggerProcessing` and its ten peer sites now always succeed.

## Test

Regression test `handleOutbound dispatches after start-then-stop (regression - processingScope silent drop)` uses the existing `testHookOnProcessOutboundMessage` hook to simulate the post-Doze lifecycle gap. Calls `start()` then `stop()`, then issues a `handleOutbound` and asserts the hook fires within 1s.

- **Pre-fix**: `TimeoutCancellationException` — silently dropped
- **Post-fix**: passes in ~5ms

All 25 `LXMRouterTest` cases remain green (CI from #12 will enforce this going forward).

## Test plan

- [x] `:lxmf-core:test` — 25/25 pass
- [x] New regression test FAILS against main, PASSES against this branch
- [ ] Downstream: rebuild Columba against this branch, rerun the post-Doze repro scenario, confirm messages dispatch
- [ ] Stacked on top: columba bump PR to lxmfKt v0.0.7 after tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)