### PR TITLE
Dedup inbound LXMessages on message.hash, not transientId (fixes #8)

### DIFF
--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -1458,9 +1458,21 @@ class LXMRouter(
             message.incoming = true
             message.method = method
 
-            // Check for duplicates
-            val transientId = message.transientId?.toHexString()
-            if (transientId != null && locallyDeliveredTransientIds.containsKey(transientId)) {
+            // Check for duplicates. Dedup on message.hash (full hash of
+            // destination_hash + source_hash + payload-without-stamp), which
+            // is set unconditionally by LXMessage.unpackFromBytes:763. The
+            // older code checked transientId, but transientId is only
+            // populated on the SENDER side during outbound packing for
+            // propagation (LXMessage.kt outbound → LXMessage.py:439); on the
+            // incoming path it's always null, so the dedup check was a
+            // perpetual no-op. This let DIRECT-delivery LXMessages large
+            // enough to trigger Resource transfer (>319 bytes) deliver
+            // twice — once via setPacketCallback firing on the final chunk,
+            // once via setResourceConcludedCallback firing on assembly. See
+            // LXMF-kt#8. Matches Python LXMRouter.py:1788/1792 which uses
+            // message.hash as the locally_delivered_transient_ids key.
+            val dedupKey = message.hash?.toHexString()
+            if (dedupKey != null && locallyDeliveredTransientIds.containsKey(dedupKey)) {
                 println("Duplicate message detected, ignoring")
                 return
             }
@@ -1533,9 +1545,10 @@ class LXMRouter(
                 }
             }
 
-            // Mark as delivered
+            // Mark as delivered. See dedupKey computation above for why
+            // we key on message.hash rather than transientId.
             val nowSeconds = System.currentTimeMillis() / 1000
-            transientId?.let {
+            dedupKey?.let {
                 locallyDeliveredTransientIds[it] = nowSeconds
                 saveTransientIdsAsync()
             }


### PR DESCRIPTION
## Summary

Any DIRECT-delivery LXMessage large enough to trigger Resource transfer (>319 bytes — i.e. every Columba / Sideband image, audio, or file attachment) was being delivered twice. The `LXMRouter` wires both `link.setPacketCallback` and `link.setResourceConcludedCallback` in `handleDeliveryLinkEstablished`; on multi-packet Resource delivery RNS legitimately fires both for the same message, and both land in `processInboundDelivery`, which has a dedup guard.

The dedup guard keyed off `message.transientId` — a **sender-side** field, only populated during outbound packing for propagation (matches [Python LXMF.LXMessage.py:439](https://github.com/markqvist/LXMF/blob/master/LXMF/LXMessage.py#L439)). On the incoming path it's always null. The containsKey check was perpetually false; the symmetric `transientId?.let { …put… }` was a perpetual no-op. Both halves of the dedup were silently disabled.

## Fix

Dedup on `message.hash` instead. `LXMessage.unpackFromBytes:763` sets `message.hash = full_hash(destination_hash + source_hash + payload-without-stamp)` unconditionally, so the value is always available on the inbound path.

Matches [Python `LXMRouter.py:1788`](https://github.com/markqvist/LXMF/blob/master/LXMF/LXMRouter.py#L1788) where `has_message(...)` checks against `locally_delivered_transient_ids`, which is itself written with `message.hash` keys at line 1792. Python conflates the two names — the map's storage name stays "transient_ids" for on-disk format compatibility, but the keys are message.hash values.

## Production impact

Anyone running Columba (or any LXMF-kt consumer) was getting duplicate inbox entries for every multi-packet DIRECT message. Doesn't affect single-packet DIRECT (≤319 bytes) or PROPAGATED delivery (different code path). Doesn't affect LXMF-kt as a sender (transientId still set normally on outbound).

## Verification

Caught by [`reticulum-conformance/tests/lxmf/test_direct.py::test_direct_with_file_attachment_multipacket`](https://github.com/torlando-tech/reticulum-conformance/blob/main/tests/lxmf/test_direct.py) — currently `xfail`'d against this bug. Once this fix lands and `reticulum-kt`'s conformance-bridge bumps its LXMF-kt pin (currently `v0.0.4`), the xfail should be removed in a follow-up conformance PR.

Local: existing `:lxmf-core:test` suite still compiles and runs (one pre-existing test failure `test message delivery attempt tracking` was failing on main before this change too — unrelated).

Net diff: +18 / -5 lines in `LXMRouter.kt` — single dedup-key swap with explanatory comment.

Fixes #8.

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._