### PR TITLE
Write wire-source transient_id for PROPAGATED + PAPER deliveries (fixes #15)

### DIFF
--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -1553,6 +1553,33 @@ class LXMRouter(
                 saveTransientIdsAsync()
             }
 
+            // Heterogeneous-key dedup: for delivery methods whose receive
+            // path queries the dedup map by WIRE-SOURCE transient_id (not
+            // message.hash), also write the wire-source key. Mirrors Python
+            // LXMRouter.py:2320 which writes transient_id alongside the
+            // message.hash from line 1792, so has_message(...) works for
+            // either key shape. See #15 for the full callsite analysis.
+            //
+            //   PROPAGATED: the propagation node sends a list of
+            //     transient_ids in its message-list response; the
+            //     wantedIds filter at LXMRouter.kt:2231 queries by that
+            //     transient_id. The propagation transient_id is
+            //     full_hash(dest_hash + encrypted_payload) — i.e.
+            //     full_hash(`data`) BEFORE we decrypt it locally.
+            //
+            //   PAPER: the paper-message ingestion path computes
+            //     transient_id = full_hash(lxmfData) at LXMRouter.kt:3023
+            //     before invoking processInboundDelivery; writing
+            //     full_hash(`data`) makes that outer dedup actually fire
+            //     on the second ingestion of the same paper message
+            //     instead of always missing and falling through to the
+            //     inner message.hash dedup.
+            if (method == DeliveryMethod.PROPAGATED || method == DeliveryMethod.PAPER) {
+                val wireTransientIdHex = Hashes.fullHash(data).toHexString()
+                locallyDeliveredTransientIds[wireTransientIdHex] = nowSeconds
+                saveTransientIdsAsync()
+            }
+
             // Annotate the message with receive-time phy metadata from the
             // delivering packet / link. Propagation-fetched messages are
             // intentionally left null because the original in-path packet

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -1545,20 +1545,16 @@ class LXMRouter(
                 }
             }
 
-            // Mark as delivered. See dedupKey computation above for why
-            // we key on message.hash rather than transientId.
-            val nowSeconds = System.currentTimeMillis() / 1000
-            dedupKey?.let {
-                locallyDeliveredTransientIds[it] = nowSeconds
-                saveTransientIdsAsync()
-            }
-
-            // Heterogeneous-key dedup: for delivery methods whose receive
-            // path queries the dedup map by WIRE-SOURCE transient_id (not
-            // message.hash), also write the wire-source key. Mirrors Python
-            // LXMRouter.py:2320 which writes transient_id alongside the
-            // message.hash from line 1792, so has_message(...) works for
-            // either key shape. See #15 for the full callsite analysis.
+            // Mark as delivered. Both keys (message.hash and, for
+            // PROPAGATED/PAPER, the wire-source transient_id) are written
+            // BEFORE the single saveTransientIdsAsync() call below — that
+            // way the launched save coroutine reads a complete map at
+            // execution time and a single file rewrite captures both
+            // entries (vs two saves where the first could race ahead of
+            // the second write). See dedupKey computation above for the
+            // message.hash rationale, and #15 for the wire-source key
+            // rationale (mirrors Python LXMRouter.py:1792 + 2320 — both
+            // keys coexist in the heterogeneous-key dedup map).
             //
             //   PROPAGATED: the propagation node sends a list of
             //     transient_ids in its message-list response; the
@@ -1574,11 +1570,18 @@ class LXMRouter(
             //     on the second ingestion of the same paper message
             //     instead of always missing and falling through to the
             //     inner message.hash dedup.
+            val nowSeconds = System.currentTimeMillis() / 1000
+            var anyKeyWritten = false
+            dedupKey?.let {
+                locallyDeliveredTransientIds[it] = nowSeconds
+                anyKeyWritten = true
+            }
             if (method == DeliveryMethod.PROPAGATED || method == DeliveryMethod.PAPER) {
                 val wireTransientIdHex = Hashes.fullHash(data).toHexString()
                 locallyDeliveredTransientIds[wireTransientIdHex] = nowSeconds
-                saveTransientIdsAsync()
+                anyKeyWritten = true
             }
+            if (anyKeyWritten) saveTransientIdsAsync()
 
             // Annotate the message with receive-time phy metadata from the
             // delivering packet / link. Propagation-fetched messages are


### PR DESCRIPTION
## Summary

Stacked on top of [#14](https://github.com/torlando-tech/LXMF-kt/pull/14). Resolves the heterogeneous-key mismatch documented in [#15](https://github.com/torlando-tech/LXMF-kt/issues/15) between `processInboundDelivery`'s post-#14 message.hash writes and the two callsites that query the dedup map by wire-source `transient_id`:

- **`LXMRouter.kt:2231`** — propagation-fetch wantedIds filter. Queried by propagation node's transient_id; pre-fix always missed → client re-downloaded every offered message every cycle.
- **`LXMRouter.kt:3027`** — paper-message ingestion. Queried by URI-derived transient_id; pre-fix always missed → outer dedup useless, falls through to inner dedup every time.

## Fix

In `processInboundDelivery`, after the existing `message.hash` write, also write `Hashes.fullHash(data)` when method is `PROPAGATED` or `PAPER`. `data` is the wire-source bytes — for PROPAGATED that's the encrypted form (`dest_hash + encrypted_payload`) which is exactly what the propagation node uses as its transient_id (matches [Python `LXMessage.py:439`](https://github.com/markqvist/LXMF/blob/master/LXMF/LXMessage.py#L439)); for PAPER it's the URI-decoded blob which the paper ingest path at `LXMRouter.kt:3023` already hashes.

Mirrors Python's heterogeneous-key design at [`LXMRouter.py:1792`](https://github.com/markqvist/LXMF/blob/master/LXMF/LXMRouter.py#L1792) (writes message.hash from delivery callback) + [`LXMRouter.py:2320`](https://github.com/markqvist/LXMF/blob/master/LXMF/LXMRouter.py#L2320) (writes transient_id from propagation_resource_concluded). Both keys coexist in `locally_delivered_transient_ids` so `has_message(...)` works for either key shape.

DIRECT and OPPORTUNISTIC don't need the wire-source write because no reader queries them by that key (matches Python — `lxmf_delivery` only writes message.hash).

## Production impact

- Propagation-fetched users (lxmd-paired Columba/Sideband flows): no longer re-download already-delivered messages on every fetch cycle. Bandwidth savings proportional to inbox depth.
- Paper-message ingestion: outer dedup short-circuits on duplicate ingests, avoiding the unpack + decrypt for known-already-delivered URIs.
- DIRECT and OPPORTUNISTIC: unchanged.

## Net diff

+27 lines, single function. Compiles clean (`:lxmf-core:compileKotlin`).

Fixes #15. Targets the #14 branch (will retarget to main once #14 merges).

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._