### PR TITLE
chore: bump rns-core / -interfaces / -test to v0.0.15

### DIFF
--- a/lxmf-core/build.gradle.kts
+++ b/lxmf-core/build.gradle.kts
@@ -20,13 +20,13 @@ dependencies {
     // api scope: lxmf-core's public API (LXMRouter, LXMessage) exposes
     // rns-core types (Destination, Identity) as parameters and return types,
     // so consumers need rns-core on their compile classpath.
-    api("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.14")
+    api("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.15")
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
     // Test dependencies for live networking tests
-    testImplementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:v0.0.14")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:v0.0.15")
 
     // MessagePack for serialization (already in rns-core, but explicit)
     implementation("org.msgpack:msgpack-core:0.9.8")
@@ -43,7 +43,7 @@ dependencies {
     testRuntimeOnly("org.slf4j:slf4j-simple:2.0.9")
 
     // Interop testing - reuse Python bridge infrastructure from rns-test
-    testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:v0.0.14")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:v0.0.15")
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
     // Compression - Apache Commons Compress for BZ2 interop tests

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
@@ -2,6 +2,7 @@ package network.reticulum.lxmf
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -186,9 +187,17 @@ class LXMRouterTest {
 
         router.handleOutbound(message)
 
-        // Process should increment delivery attempts
-        router.processOutbound()
-
+        // handleOutbound() also launches an async processOutbound() via
+        // triggerProcessing(); the synchronous call below races it for
+        // outboundProcessingMutex. Poll until at least one attempt has
+        // been recorded — same deflake pattern as the sibling test
+        // "test direct delivery method increments attempts".
+        withTimeout(5_000) {
+            while (message.deliveryAttempts == 0) {
+                delay(50)
+                router.processOutbound()
+            }
+        }
         assertTrue(message.deliveryAttempts > 0)
     }
 
@@ -291,15 +300,21 @@ class LXMRouterTest {
         assertEquals(0, message.deliveryAttempts)
 
         router.handleOutbound(message)
-        router.processOutbound()
+        // handleOutbound() also launches an async processOutbound() via
+        // triggerProcessing(), which races with the synchronous call below
+        // for outboundProcessingMutex.tryLock(). Whichever loses early-
+        // returns without doing work. Pre-PR-#18 the increment was
+        // deterministic on the synchronous path; post-#18 we need to
+        // poll until at least one attempt has been recorded — same
+        // deflake pattern test_max_delivery_attempts uses.
+        withTimeout(5_000) {
+            while (message.deliveryAttempts == 0) {
+                delay(50)
+                router.processOutbound()
+            }
+        }
 
-        // Direct delivery without path/link should increment attempts
-        assertEquals(1, message.deliveryAttempts)
-
-        // Process again
-        router.processOutbound()
-
-        // May retry depending on timing
+        // Direct delivery without path/link should have incremented attempts
         assertTrue(message.deliveryAttempts >= 1)
     }
 


### PR DESCRIPTION
## Summary
Pulls in three production-relevant fixes from reticulum-kt:

| PR | Fix |
|---|---|
| [reticulum-kt#61](https://github.com/torlando-tech/reticulum-kt/pull/61) | Resource double-fire — every received Resource was delivered twice on receive |
| [reticulum-kt#63](https://github.com/torlando-tech/reticulum-kt/pull/63) | Shutdown race that closed the Room DB while writes were mid-transaction (Sentry COLUMBA-8R, 8X) |
| [reticulum-kt#59](https://github.com/torlando-tech/reticulum-kt/pull/59) | Receiver-side link.establishedCallback race |

Plus diagnostic improvement [#60](https://github.com/torlando-tech/reticulum-kt/pull/60) (conformance bridge stdout→stderr) which only matters for the cross-impl conformance harness, not LXMF runtime.

## Production impact (the load-bearing one is #61)
LXMF-kt's \`LXMRouter.handleResourceConcluded\` was the downstream consumer of reticulum-kt's double-fired Resource callback. Any multi-packet DIRECT or PROPAGATED LXMessage that fit the RESOURCE-mode threshold (~packet MTU) was being delivered twice on the receiver. Surfaced in lxmf-conformance:

\`\`\`
test_combined_text_and_attachment_over_resource[python->kotlin]   FAIL: received 2 messages, expected 1
test_combined_text_and_attachment_over_resource[kotlin->kotlin]   FAIL: received 2 messages, expected 1
test_direct_large_message_resource_transfer[python->kotlin]       FAIL: received 2 messages, expected 1
test_direct_large_message_resource_transfer[kotlin->kotlin]       FAIL: received 2 messages, expected 1
\`\`\`

After this bump, those go to PASS. Verified locally with the conformance suite running \`--impls python,kotlin\`: 28/28 pass.

## Test plan
- [x] \`./gradlew :lxmf-core:dependencies\` resolves rns-core/v0.0.15 successfully
- [x] \`./gradlew :lxmf-core:compileKotlin\` builds clean against the new version
- [x] Full conformance suite: 28/28 pass (run separately against the bridge built from this rev + lxmf-conformance#2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)