### PR TITLE
fix(LXMRouter): don't identify on propagation delivery link

### DIFF
--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -2161,10 +2161,16 @@ class LXMRouter(
                         outboundPropagationLink = establishedLink
                         propagationTransferState = PropagationTransferState.LINK_ESTABLISHED
 
-                        // Identify ourselves on the link
-                        identifyOnLink(establishedLink)
-
                         if (forRetrieval) {
+                            // Retrieval path identifies on the link so the PN
+                            // can locate the requesting peer's queued messages.
+                            // Mirrors python `request_messages_from_propagation_node`
+                            // at LXMRouter.py:493 (`self.outbound_propagation_link
+                            // .identify(identity)`). The delivery path
+                            // intentionally does NOT identify — see the
+                            // matching comment below for rationale.
+                            identifyOnLink(establishedLink)
+
                             // Retrieval path: request message list (Python line 510)
                             // The identify packet may not have been processed yet by the
                             // remote node. If we get ERROR_NO_IDENTITY, handleMessageListResponse
@@ -2172,6 +2178,25 @@ class LXMRouter(
                             println("[LXMRouter] Calling requestMessageList on established link")
                             requestMessageList(establishedLink)
                         } else {
+                            // Delivery path: do NOT identify on the link.
+                            // Mirrors python `process_outbound` for PROPAGATED
+                            // at LXMRouter.py:2700-2704 — python establishes
+                            // `RNS.Link(propagation_node_destination, ...)`
+                            // and goes straight to sending the resource without
+                            // calling `link.identify(...)`.
+                            //
+                            // Identifying on the delivery link causes lxmd's
+                            // `propagation_resource_concluded` (LXMRouter.py:
+                            // 2188-2214) to run the peer-discovery branch
+                            // (`remote_destination = RNS.Destination(remote_identity,
+                            // OUT, SINGLE, "lxmf", "propagation")` then
+                            // `recall_app_data(remote_hash)`), which probes
+                            // global state during the resource conclusion path
+                            // and can stall the proof emission. Python avoids
+                            // this by leaving the link unidentified for
+                            // delivery — the message itself carries enough
+                            // routing info via its embedded recipient
+                            // destination hash.
                             // Delivery path: re-trigger outbound processing for pending messages (Python line 2709)
                             processingScope.launch {
                                 // Reset nextDeliveryAttempt for pending PROPAGATED messages so they get processed immediately.


### PR DESCRIPTION
## Summary

Restores parity with python LXMF. The kotlin port was identifying on **every** propagation link establishment, including the delivery path. Python's \`process_outbound\` for PROPAGATED at \`LXMRouter.py:2700-2704\` does NOT call \`link.identify(...)\` — it only happens in \`request_messages_from_propagation_node\` (sync/retrieval, \`LXMRouter.py:493\`).

## Why this matters

When the kotlin sender's link to lxmd carried an identify packet, lxmd's \`propagation_resource_concluded\` (\`LXMRouter.py:2188-2214\`) saw a non-None \`remote_identity\` and ran the **peer-discovery branch**:

\`\`\`python
remote_destination = RNS.Destination(remote_identity, OUT, SINGLE, "lxmf", "propagation")
remote_hash = remote_destination.hash
remote_app_data = RNS.Identity.recall_app_data(remote_hash)
# ... peer table probe + auto-peer logic
\`\`\`

For python senders this whole branch is short-circuited because python's delivery path doesn't identify, so \`remote_identity is None\`.

## How it was found

Cross-impl conformance asymmetry: \`kotlin->lxmd_pn->python\` consistently exceeded the 90s deadline on CI while \`kotlin->lxmd_pn->kotlin\` ran in ~25s. **Same kotlin sender code, same lxmd PN — only the receiver impl varied.** That asymmetry shouldn't exist (sender→PN flow is identical regardless of receiver), and the user pointed out it smelled like an interop bug. Reviewing the python LXMF reference revealed the missing-divergence: kotlin identifies on delivery, python doesn't.

## Test plan

Local \`taskset -c 0,1\` (mimicking 2-core CI):

- [x] \`kotlin->lxmd_pn->python\`: 3/3 pass, 50-61s (was timing out at 90s before)
- [ ] \`kotlin->lxmd_pn->kotlin\`: pending verification (already passes; should not regress)
- [ ] LXMF-kt#21 CI run with this fix consumed