### PR TITLE
fix(LXMessage): accept Nil fields, preserve wire encoding for hash

### DIFF
--- a/conformance-bridge/build.gradle.kts
+++ b/conformance-bridge/build.gradle.kts
@@ -19,6 +19,11 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     implementation("org.json:json:20231013")
 
+    // msgpack-core for the byte-level lxmf_decode_bytes command, which
+    // operates directly on the wire format rather than going through
+    // the LXMessage class. Same version as :lxmf-core uses internally.
+    implementation("org.msgpack:msgpack-core:0.9.8")
+
     // Logging — use slf4j-simple but at WARN by default so RNS chatter
     // doesn't interleave with the JSON-RPC stdout protocol.
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")

--- a/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
+++ b/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
@@ -786,7 +786,7 @@ private fun cmdLxmfDecodeBytes(params: JSONObject): JSONObject {
         u.skipValue() // timestamp
         u.skipValue() // title
         u.skipValue() // content
-        val isNil = u.nextFormat.valueType.name == "NIL"
+        val isNil = u.tryUnpackNil()
         u.close()
         isNil
     } catch (_: Exception) {

--- a/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
+++ b/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
@@ -728,6 +728,89 @@ private fun cmdLxmfGetMessageState(params: JSONObject): JSONObject {
     return JSONObject().put("state", state)
 }
 
+/**
+ * Decode raw LXMF wire bytes and return parsed components + computed hash.
+ *
+ * Byte-level conformance command. Does NOT require lxmf_init — operates
+ * on the LXMessage decoder in isolation. The whole point is to exercise
+ * the msgpack/payload parsing layer directly, against payload shapes
+ * that may be impossible to elicit through normal send commands (e.g.
+ * a fields slot encoded as msgpack Nil, which kotlin's own sender never
+ * emits but iOS LXMF does — and which kotlin's decoder used to throw on,
+ * silently dropping every iOS-originated message).
+ *
+ * Mirrors lxmf_python.py::cmd_lxmf_decode_bytes.
+ *
+ * Implements the same logic shape as LXMessage.unpackFromBytes (the very
+ * code path under test) but without going through Identity recall /
+ * signature validation, so test bytes can use a dummy signature and
+ * unknown destination/source hashes.
+ */
+private fun cmdLxmfDecodeBytes(params: JSONObject): JSONObject {
+    val DEST_LEN = 16
+    val SIG_LEN = 64
+
+    val lxmfBytesHex = params.optString("lxmf_bytes", "")
+    val lxmfBytes = try {
+        hexToBytes(lxmfBytesHex)
+    } catch (e: Exception) {
+        return JSONObject().put("decode_error", "hex parse: ${e::class.simpleName}: ${e.message}")
+    }
+
+    if (lxmfBytes.size < 2 * DEST_LEN + SIG_LEN) {
+        return JSONObject().put("decode_error", "lxmf_bytes too short: ${lxmfBytes.size}")
+    }
+
+    // Call the production decoder directly. This is the WHOLE POINT of the
+    // command — to exercise the actual LXMessage.unpackFromBytes code path
+    // that runs in the wild, not a parallel re-implementation. A bridge
+    // that re-implemented decode here would silently mask production
+    // decoder bugs (e.g. the iOS-Nil-fields landmine that took weeks to
+    // find precisely because the conformance suite couldn't reach the
+    // production code path).
+    val msg = network.reticulum.lxmf.LXMessage.unpackFromBytes(lxmfBytes)
+        ?: return JSONObject().put(
+            "decode_error",
+            "LXMessage.unpackFromBytes returned null — see bridge stderr for the underlying exception"
+        )
+
+    // Detect whether the wire form had Nil fields by re-parsing just that
+    // byte position. This is shape-level — production keeps fields as a
+    // (possibly empty) Map; the wire-side Nil/Map distinction is only
+    // load-bearing through the hash computation which production already
+    // handles. For the test surface, expose it diagnostically.
+    val packedPayload = lxmfBytes.copyOfRange(2 * DEST_LEN + SIG_LEN, lxmfBytes.size)
+    val fieldsWasNil = try {
+        val u = org.msgpack.core.MessagePack.newDefaultUnpacker(packedPayload)
+        u.unpackArrayHeader()
+        u.skipValue() // timestamp
+        u.skipValue() // title
+        u.skipValue() // content
+        val isNil = u.nextFormat.valueType.name == "NIL"
+        u.close()
+        isNil
+    } catch (_: Exception) {
+        false
+    }
+
+    val title = msg.title
+    val content = msg.content
+    val titleHex = title.toByteArray(Charsets.UTF_8).toHexString()
+    val contentHex = content.toByteArray(Charsets.UTF_8).toHexString()
+
+    return JSONObject()
+        .put("destination_hash", msg.destinationHash.toHexString())
+        .put("source_hash", msg.sourceHash.toHexString())
+        .put("signature", (msg.signature ?: ByteArray(0)).toHexString())
+        .put("timestamp", msg.timestamp ?: 0.0)
+        .put("title_hex", titleHex)
+        .put("content_hex", contentHex)
+        .put("fields_was_nil", fieldsWasNil)
+        .put("fields_count", msg.fields.size)
+        .put("stamp", msg.stamp?.toHexString() ?: JSONObject.NULL)
+        .put("message_hash", (msg.hash ?: ByteArray(0)).toHexString())
+}
+
 private fun cmdLxmfShutdown(params: JSONObject): JSONObject {
     // Set the shuttingDown flag FIRST so any callbacks the router fires
     // during teardown can't repopulate cleared collections behind us.
@@ -791,6 +874,7 @@ private val COMMANDS: Map<String, (JSONObject) -> JSONObject> = mapOf(
     "lxmf_sync_inbound" to ::cmdLxmfSyncInbound,
     "lxmf_get_received_messages" to ::cmdLxmfGetReceivedMessages,
     "lxmf_get_message_state" to ::cmdLxmfGetMessageState,
+    "lxmf_decode_bytes" to ::cmdLxmfDecodeBytes,
     "lxmf_shutdown" to ::cmdLxmfShutdown,
 )
 

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessage.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessage.kt
@@ -698,8 +698,19 @@ class LXMessage private constructor(
                 val contentBytes = ByteArray(contentLen)
                 unpacker.readPayload(contentBytes)
 
-                // [3] fields
-                val fields = unpackFields(unpacker)
+                // [3] fields — may be msgpack Nil (interop: iOS LXMF and python's
+                // `set_fields(None)` both produce Nil here; python tolerates this on
+                // unpack via LXMessage.py:755 + set_fields() at LXMessage.py:220-224
+                // which accepts None and normalizes to {}). Track wire encoding so
+                // we can repack identically when a stamp is present.
+                val fieldsWasNil = unpacker.nextFormat.valueType.name == "NIL"
+                val fields =
+                    if (fieldsWasNil) {
+                        unpacker.unpackNil()
+                        mutableMapOf()
+                    } else {
+                        unpackFields(unpacker)
+                    }
 
                 // [4] stamp (optional)
                 val stamp: ByteArray? =
@@ -714,8 +725,17 @@ class LXMessage private constructor(
 
                 unpacker.close()
 
-                // Repack payload without stamp for hash verification
-                val payloadWithoutStamp = repackPayload(timestamp, titleBytes, contentBytes, fields)
+                // Mirror python LXMessage.py:742-747: only re-pack to strip the stamp.
+                // For stampless messages use the original packedPayload bytes directly —
+                // any msgpack encoding round-trip risks a hash mismatch (e.g. empty fields
+                // encoded as Nil 0xc0 vs empty Map 0x80). With a stamp present, repack
+                // preserving the original fields encoding (Nil if it was Nil on the wire).
+                val payloadWithoutStamp =
+                    if (stamp == null) {
+                        packedPayload
+                    } else {
+                        repackPayload(timestamp, titleBytes, contentBytes, fields, fieldsWasNil)
+                    }
 
                 // Build hashed part
                 val hashedPart = destinationHash + sourceHash + payloadWithoutStamp
@@ -864,12 +884,21 @@ class LXMessage private constructor(
 
         /**
          * Repack payload without stamp for hash verification.
+         *
+         * [fieldsWasNil] preserves the original wire encoding for the fields
+         * position. If the inbound payload encoded fields as msgpack Nil
+         * (`0xc0`, what iOS LXMF and python's `msgpack.packb(None)` produce),
+         * we must emit Nil here too — emitting an empty Map (`0x80`) instead
+         * would change the byte representation and break the message hash.
+         * Mirrors python `msgpack.packb(unpacked_payload)` round-trip
+         * behavior at LXMessage.py:745, which preserves None as Nil.
          */
         private fun repackPayload(
             timestamp: Double,
             titleBytes: ByteArray,
             contentBytes: ByteArray,
             fields: Map<Int, Any>,
+            fieldsWasNil: Boolean = false,
         ): ByteArray {
             val buffer = ByteArrayOutputStream()
             val packer = MessagePack.newDefaultPacker(buffer)
@@ -888,11 +917,15 @@ class LXMessage private constructor(
             packer.packBinaryHeader(contentBytes.size)
             packer.writePayload(contentBytes)
 
-            // [3] fields
-            packer.packMapHeader(fields.size)
-            for ((key, value) in fields) {
-                packer.packInt(key)
-                repackValue(packer, value)
+            // [3] fields — emit Nil if that's what the wire had, else Map
+            if (fieldsWasNil && fields.isEmpty()) {
+                packer.packNil()
+            } else {
+                packer.packMapHeader(fields.size)
+                for ((key, value) in fields) {
+                    packer.packInt(key)
+                    repackValue(packer, value)
+                }
             }
 
             packer.close()

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessage.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessage.kt
@@ -703,10 +703,11 @@ class LXMessage private constructor(
                 // unpack via LXMessage.py:755 + set_fields() at LXMessage.py:220-224
                 // which accepts None and normalizes to {}). Track wire encoding so
                 // we can repack identically when a stamp is present.
-                val fieldsWasNil = unpacker.nextFormat.valueType.name == "NIL"
+                // tryUnpackNil() peek-and-consumes in one call; if it returns true the
+                // Nil byte is already consumed so no follow-up unpackNil() is needed.
+                val fieldsWasNil = unpacker.tryUnpackNil()
                 val fields =
                     if (fieldsWasNil) {
-                        unpacker.unpackNil()
                         mutableMapOf()
                     } else {
                         unpackFields(unpacker)


### PR DESCRIPTION
## Summary

Closes the iOS LXMF interop gap: kotlin's decoder was silently dropping every iOS-originated message because it rejected the `msgpack Nil (0xc0)` encoding for empty fields and demanded an empty Map (`0x80`) instead. Two coordinated decoder fixes that bring kotlin into line with python's reference behavior.

- **Bug 1**: `unpackFields` rejected msgpack Nil with `MessageTypeException`. Python tolerates Nil at `LXMessage.py:755` (raw read with no type validation) + `LXMessage.py:220-224` (`set_fields(None)` normalizes to `{}`).
- **Bug 2**: kotlin always re-packed for hash; python only re-packs when stripping a stamp (`LXMessage.py:742-747`). Stampless messages now use the original packed bytes for hash, matching python.

Both changes **remove** existing port-mirror-reference deviations rather than introducing new ones, so no `port-deviations.md` entry is needed.

## Why now

Production failure on Columba 2026-04-30: every iOS opportunistic message produced `Error unpacking LXMF message: Expected Map, but got Nil (c0)` in kotlin's logcat. Bug had been present since the kotlin port was written but never bit because both kotlin and python senders emit empty Map for empty fields — only iOS LXMF emits Nil naturally.

## Conformance suite changes

- `conformance-bridge`: new `lxmf_decode_bytes` command wraps production `LXMessage.unpackFromBytes` for byte-level conformance testing. Companion PR in lxmf-conformance adds the test surface.
- `settings.gradle.kts`: env-gate `:conformance-bridge` behind `INCLUDE_CONFORMANCE_BRIDGE=1` so a Gradle-9 composite-build override from a downstream consumer (Columba) doesn't choke on the conformance-bridge's Shadow plugin.

## Test plan

- [x] `INCLUDE_CONFORMANCE_BRIDGE=1 ./gradlew :conformance-bridge:shadowJar` succeeds
- [x] `./gradlew :app:assembleNoSentryDebug` from Columba with `LOCAL_LXMF_KT=...` composite-build override succeeds (Gradle-9 consumer compatibility)
- [x] Conformance suite (lxmf-conformance PR): 30/30 cases pass with this fix; 4/15 kotlin cases fail without it (pre-fix:4-elem Nil, 5-elem Nil-with-stamp, hash-matrix Nil cases)
- [x] Live verification: APK with this fix installed on Android device, iOS→kotlin opportunistic message arrives and is delivered to UI (was silently dropped before)

## Stack

This PR is one of two:

1. (this PR) LXMF-kt: production fix + bridge command + Gradle-9 compat
2. lxmf-conformance: byte-level test surface that locks in the invariant cross-impl

Companion lxmf-conformance PR depends on this one's bridge command.

---
🤖 Generated with claude-opus-4-7[1m]