### PR TITLE
feat(conformance-bridge): accept optional timestamp param on lxmf_send_*

### DIFF
--- a/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
+++ b/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
@@ -540,6 +540,16 @@ private fun cmdLxmfSendCommon(
         m.hash?.let { recordOutboundState(it.toHexString(), stateToString(m.state)) }
     }
 
+    // Optional explicit timestamp for tests that need byte-for-byte
+    // reproducible wire bytes (notably the dedup conformance test, where
+    // two consecutive sends must produce the same message_hash so the
+    // receiver's dedup check actually has something to compare against).
+    // LXMessage.pack() at LXMessage.kt:231-233 only sets timestamp =
+    // currentTimeMillis()/1000 when null, so a pre-set value sticks.
+    if (params.has("timestamp") && !params.isNull("timestamp")) {
+        message.timestamp = params.getDouble("timestamp")
+    }
+
     runBlocking { router.handleOutbound(message) }
     val msgHashHex = message.hash?.toHexString() ?: ""
     if (msgHashHex.isNotEmpty()) {


### PR DESCRIPTION
## Summary

Adds an optional `timestamp` (float) param to the conformance bridge's `cmdLxmfSendCommon`. When set, it pins the LXMessage timestamp before pack(), producing byte-for-byte reproducible wire bytes across consecutive sends with identical inputs.

10 lines, single function, no production code touched.

## Why

Required for the dedup conformance test (lxmf-conformance#12) where two consecutive sends must produce the same `message_hash` so the receiver's dedup check has something to compare against. Without forced timestamp, each `time.time()` produces a fresh value → different message_hash → no dedup test possible.

`LXMessage.pack()` at `LXMessage.kt:231-233` only sets timestamp when null, so a pre-set value sticks naturally.

## Mirror PR

Companion python bridge change ships in lxmf-conformance with the dedup test (since the python bridge lives in that repo). Both bridges accept the param the same way so a single `BridgeNode.send_*` wrapper passes through to either impl uniformly.

## Test plan

- [x] Build succeeds: `INCLUDE_CONFORMANCE_BRIDGE=1 ./gradlew :conformance-bridge:shadowJar`
- [x] Dedup test (lxmf-conformance) passes 8/8 across all 4 (sender, receiver) impl pairs with this change

---
🤖 Generated with claude-opus-4-7[1m]