### PR TITLE
feat(lxmf-core): force consumers to handle unverified deliveries via sealed LXMessageDelivery

### DIFF
--- a/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
+++ b/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
@@ -14,6 +14,7 @@ import network.reticulum.interfaces.toRef
 import network.reticulum.lxmf.DeliveryMethod
 import network.reticulum.lxmf.LXMRouter
 import network.reticulum.lxmf.LXMessage
+import network.reticulum.lxmf.LXMessageDelivery
 import network.reticulum.lxmf.MessageState
 import network.reticulum.transport.Transport
 import org.json.JSONArray
@@ -351,11 +352,29 @@ private fun cmdLxmfInit(params: JSONObject): JSONObject {
 
         deliveryDest = router.registerDeliveryIdentity(identity, displayName = displayName)
 
-        router.registerDeliveryCallback { message ->
+        router.registerDeliveryCallback { delivery ->
             // Drop late callbacks that fire on background threads after
             // cmdLxmfShutdown cleared the inbox. Otherwise they re-add
             // the entry and the next test sees stale state.
             if (BridgeState.shuttingDown) return@registerDeliveryCallback
+            // Unwrap the sealed delivery type. Both branches feed the
+            // same inbox so existing wire-E2E tests are unaffected; the
+            // unverified flag is exposed via two new JSON fields so
+            // future conformance tests (lxmf-conformance#10) can assert
+            // on signature-validation contract per impl.
+            val message: LXMessage = delivery.message
+            val unverifiedFlag: Boolean
+            val unverifiedReason: Int?
+            when (delivery) {
+                is LXMessageDelivery.Verified -> {
+                    unverifiedFlag = false
+                    unverifiedReason = null
+                }
+                is LXMessageDelivery.Unverified -> {
+                    unverifiedFlag = true
+                    unverifiedReason = delivery.reason.value
+                }
+            }
             val entry = JSONObject()
             entry.put("message_hash", message.hash?.toHexString() ?: "")
             entry.put("source_hash", message.sourceHash.toHexString())
@@ -366,6 +385,11 @@ private fun cmdLxmfInit(params: JSONObject): JSONObject {
             entry.put("ack_status", "received")
             entry.put("received_at_ms", System.currentTimeMillis())
             entry.put("fields", encodeMessageFields(message))
+            // Surface signature-validation state for cross-impl tests.
+            // Always present so test assertions can compare on every
+            // entry without nullable-key gymnastics.
+            entry.put("unverified", unverifiedFlag)
+            entry.put("unverified_reason", unverifiedReason ?: JSONObject.NULL)
             // Increment seq AND add to inbox under a single lock acquisition.
             // Splitting them across two `withLock` blocks lets a poll between
             // the two release `last_seq=N` (already incremented) without the

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -164,8 +164,17 @@ class LXMRouter(
 
     // ===== Callbacks =====
 
-    /** Callback for delivered messages */
-    private var deliveryCallback: ((LXMessage) -> Unit)? = null
+    /**
+     * Callback for delivered inbound messages.
+     *
+     * Receives an [LXMessageDelivery] (sealed `Verified | Unverified`)
+     * rather than a raw [LXMessage] so consumers cannot accidentally
+     * treat unverified messages as authentic. Kotlin's exhaustive `when`
+     * forces the consumer to make an explicit policy decision for the
+     * Unverified branch. See [LXMessageDelivery] KDoc for threat-model
+     * context and the SIGNATURE_INVALID-vs-SOURCE_UNKNOWN distinction.
+     */
+    private var deliveryCallback: ((LXMessageDelivery) -> Unit)? = null
 
     /** Callback for message delivery failures */
     private var failedDeliveryCallback: ((LXMessage) -> Unit)? = null
@@ -432,14 +441,31 @@ class LXMRouter(
     }
 
     /**
-     * Register a callback for delivered messages.
+     * Register a callback for delivered inbound messages.
      *
-     * The callback will be invoked when a message is successfully received
-     * and validated.
+     * The callback receives an [LXMessageDelivery] sealed type rather than
+     * a raw [LXMessage]. Consumers MUST exhaustively handle both
+     * [LXMessageDelivery.Verified] (signature checked, source identity
+     * known and matched) and [LXMessageDelivery.Unverified] (source
+     * identity not yet observed on this peer's RNS — treat with
+     * suspicion, e.g. show a "this sender's identity has not been
+     * verified" warning in your UI).
      *
-     * @param callback Function to call with delivered messages
+     * The router has already filtered [UnverifiedReason.SIGNATURE_INVALID]
+     * (the "tampered message claiming to be from a known sender" case)
+     * before invoking this callback — those never reach consumers.
+     * See [LXMessageDelivery] KDoc for full threat model.
+     *
+     * Port deviation from python: python's `register_delivery_callback`
+     * (LXMRouter.py:356) takes a `(LXMessage) -> Unit`; the kotlin port
+     * uses a sealed type so the kotlin compiler can prevent the
+     * silent-accept-unverified mistake at compile time. Documented in
+     * `port-deviations.md`.
+     *
+     * @param callback Function called with each delivered message wrapped
+     *   in an [LXMessageDelivery] sum type.
      */
-    fun registerDeliveryCallback(callback: (LXMessage) -> Unit) {
+    fun registerDeliveryCallback(callback: (LXMessageDelivery) -> Unit) {
         deliveryCallback = callback
     }
 
@@ -1651,8 +1677,32 @@ class LXMRouter(
                 // threads data in via a non-standard path; leave fields null.
             }
 
-            // Invoke delivery callback
-            deliveryCallback?.invoke(message)
+            // Wrap the message in the sealed LXMessageDelivery type before
+            // invoking the consumer callback. SIGNATURE_INVALID was already
+            // dropped at the signature-validation block earlier in this
+            // method (search for `unverifiedReason` above) — by the time
+            // execution reaches here, message.unverifiedReason is either
+            // null (signatureValidated=true) or SOURCE_UNKNOWN. The
+            // !signatureValidated branch defensively defaults to
+            // SOURCE_UNKNOWN if unverifiedReason is somehow null, since
+            // that's the only legitimate state reachable here.
+            //
+            // Two coupled port-deviations from python (both in
+            // port-deviations.md, category "safety-strict default"):
+            // 1) The SIGNATURE_INVALID drop above (python delivers these).
+            // 2) The sealed-type wrapping here (python passes a raw
+            //    LXMessage). Together they close the signature-forgery
+            //    class for any LXMF-kt consumer regardless of whether
+            //    the consumer remembers to check signatureValidated.
+            val delivery = if (message.signatureValidated) {
+                LXMessageDelivery.Verified(message)
+            } else {
+                LXMessageDelivery.Unverified(
+                    message = message,
+                    reason = message.unverifiedReason ?: UnverifiedReason.SOURCE_UNKNOWN,
+                )
+            }
+            deliveryCallback?.invoke(delivery)
         } catch (e: Exception) {
             println("Error processing inbound delivery: ${e.message}")
         }

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessageDelivery.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessageDelivery.kt
@@ -1,0 +1,106 @@
+package network.reticulum.lxmf
+
+/**
+ * Result of decoding an inbound LXMessage paired with its signature
+ * verification state.
+ *
+ * Callbacks registered via [LXMRouter.registerDeliveryCallback] receive
+ * an [LXMessageDelivery] rather than a raw [LXMessage] so consumers
+ * cannot accidentally treat unverified messages as authentic — the
+ * kotlin compiler forces an exhaustive `when` over the two subtypes.
+ *
+ * # Threat model context
+ *
+ * LXMF wire encryption protects *confidentiality* (only the recipient
+ * can read messages addressed to them) but does NOT provide
+ * *authenticity* on its own. Authenticity comes from the LXMessage
+ * signature, which the sender computes over `dest_hash + source_hash +
+ * packed_payload + message_hash` using its identity private key.
+ *
+ * Anyone who knows a recipient's destination hash can craft a packet
+ * encrypted to that recipient (the recipient's public key is in their
+ * announce — it's public). If the recipient does not check the
+ * signature on receive, the packet is delivered as authentic from
+ * whichever source the attacker put in the source_hash slot.
+ *
+ * The python LXMF library (`LXMRouter.lxmf_delivery`) delivers all
+ * decoded messages to the consumer callback regardless of signature
+ * status, expecting the consumer to filter on `message.signature_
+ * validated`. Sideband enforces that contract by displaying a hard
+ * "this message is likely to be fake" banner; consumers that don't
+ * filter (Columba pre-this-PR) silently render forged messages as
+ * authentic.
+ *
+ * # What LXMF-kt does
+ *
+ * Two layers of defense:
+ *
+ *  1. The router unconditionally drops [UnverifiedReason.SIGNATURE_INVALID]
+ *     at `LXMRouter.processInboundDelivery` (the source identity was
+ *     known and the signature did not validate against it — the
+ *     "tampered" case). These never reach consumers. This is a
+ *     port-mirror-reference deviation from python documented in
+ *     `port-deviations.md`.
+ *
+ *  2. The router wraps everything else in [LXMessageDelivery] before
+ *     invoking the callback. Verified messages and
+ *     [UnverifiedReason.SOURCE_UNKNOWN] messages BOTH reach the
+ *     consumer, but in distinct sealed-type branches that the kotlin
+ *     compiler will not let the consumer collapse into a single arm.
+ *     SOURCE_UNKNOWN cannot be silently dropped at the router layer
+ *     because it represents a legitimate first-contact case (the
+ *     sender's announce hasn't yet propagated to this receiver).
+ *
+ * # Wire compatibility
+ *
+ * This type is purely a kotlin API surface. LXMessage wire encoding
+ * and the LXMRouter inbound packet processing are unchanged. Cross-impl
+ * interop with python LXMF and iOS LXMF is unaffected.
+ */
+public sealed class LXMessageDelivery {
+    /** The decoded message, with its raw [LXMessage.signatureValidated] flag intact. */
+    public abstract val message: LXMessage
+
+    /**
+     * Signature was verified against a known source identity.
+     *
+     * Safe to deliver to user-facing surfaces without an authenticity
+     * warning. The consumer's existing message-handling code path is
+     * appropriate.
+     */
+    public data class Verified(
+        override val message: LXMessage,
+    ) : LXMessageDelivery()
+
+    /**
+     * Signature could not be verified.
+     *
+     * Reaches the consumer only when [reason] is
+     * [UnverifiedReason.SOURCE_UNKNOWN] — the source identity has not
+     * been observed on this peer's RNS yet, so there is no public key
+     * available to validate the signature against. Common in legitimate
+     * first-contact scenarios when the sender's announce has not yet
+     * propagated.
+     *
+     * The [UnverifiedReason.SIGNATURE_INVALID] case (source identity
+     * IS known and signature does NOT validate — the "tampered" case)
+     * is dropped at the router layer and never reaches this branch.
+     *
+     * Consumer policy choices (in order of decreasing strictness):
+     *  - Drop entirely. Most strict, but loses legitimate first-contact
+     *    messages from peers whose announces haven't propagated.
+     *  - Quarantine to a separate inbox section the user must opt into
+     *    viewing. Stronger UI friction.
+     *  - Ingest with a hard visual warning on every bubble (mirrors
+     *    Sideband's pattern). User has full information; can choose
+     *    to trust or not. Recommended default for chat-style apps.
+     *
+     * Whichever the consumer picks, it MUST do something explicit —
+     * silently treating Unverified as Verified is the bug class this
+     * sealed type prevents.
+     */
+    public data class Unverified(
+        override val message: LXMessage,
+        public val reason: UnverifiedReason,
+    ) : LXMessageDelivery()
+}

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessageDelivery.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessageDelivery.kt
@@ -102,5 +102,21 @@ public sealed class LXMessageDelivery {
     public data class Unverified(
         override val message: LXMessage,
         public val reason: UnverifiedReason,
-    ) : LXMessageDelivery()
+    ) : LXMessageDelivery() {
+        init {
+            // Make the documented invariant structural rather than just
+            // KDoc convention. The router unconditionally drops
+            // SIGNATURE_INVALID at processInboundDelivery before this
+            // wrapper is constructed, so any code path that reaches
+            // this constructor with SIGNATURE_INVALID is a bug — most
+            // likely a misuse of the API by a test or a hand-rolled
+            // delivery path that didn't replicate the router's
+            // signature-check policy. Failing fast at construction
+            // surfaces that bug at the call site instead of letting
+            // it silently propagate to consumer code.
+            require(reason != UnverifiedReason.SIGNATURE_INVALID) {
+                "SIGNATURE_INVALID is dropped at the router layer and must not be wrapped in Unverified"
+            }
+        }
+    }
 }

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
@@ -66,8 +66,8 @@ class LXMRouterTest {
     fun `test register delivery callback`() {
         var receivedMessage: LXMessage? = null
 
-        router.registerDeliveryCallback { message ->
-            receivedMessage = message
+        router.registerDeliveryCallback { delivery ->
+            receivedMessage = delivery.message
         }
 
         // Callback is registered (we can't easily test it fires without full transport)
@@ -620,7 +620,22 @@ class LXMRouterTest {
     @Test
     fun `opportunistic delivery annotates LXMessage with packet phy metadata`() {
         val received = CopyOnWriteArrayList<LXMessage>()
-        router.registerDeliveryCallback { received.add(it) }
+        // Tests assert on the LXMessage payload, not the verification
+        // wrapper; unwrap the sealed delivery type. Production code MUST
+        // exhaustively handle both Verified and Unverified — these tests
+        // only exercise the Verified path because they construct messages
+        // signed by known identities (no Unverified state reachable here).
+        router.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> received.add(delivery.message)
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery in a test that should only " +
+                        "produce verified messages — sender's identity should have been " +
+                        "registered with receiver's RNS via Identity.remember(). " +
+                        "Reason: ${delivery.reason}, source: ${delivery.message.sourceHash.toHexString()}"
+                )
+            }
+        }
 
         val destinationIdentity = Identity.create()
         val deliveryDest = router.registerDeliveryIdentity(destinationIdentity, "MetaNode")
@@ -685,7 +700,22 @@ class LXMRouterTest {
         // path under test — the null-on-propagated branch in the
         // annotation block — is exercised exactly as in prod.
         val received = CopyOnWriteArrayList<LXMessage>()
-        router.registerDeliveryCallback { received.add(it) }
+        // Tests assert on the LXMessage payload, not the verification
+        // wrapper; unwrap the sealed delivery type. Production code MUST
+        // exhaustively handle both Verified and Unverified — these tests
+        // only exercise the Verified path because they construct messages
+        // signed by known identities (no Unverified state reachable here).
+        router.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> received.add(delivery.message)
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery in a test that should only " +
+                        "produce verified messages — sender's identity should have been " +
+                        "registered with receiver's RNS via Identity.remember(). " +
+                        "Reason: ${delivery.reason}, source: ${delivery.message.sourceHash.toHexString()}"
+                )
+            }
+        }
 
         // Set up a delivery destination whose identity we control so we
         // can also build an OUT-direction destination that encrypts for it.
@@ -773,7 +803,22 @@ class LXMRouterTest {
         // test exercises link.getRssi/getSnr/attachedInterfaceHash/
         // expectedHops as production does.
         val received = CopyOnWriteArrayList<LXMessage>()
-        router.registerDeliveryCallback { received.add(it) }
+        // Tests assert on the LXMessage payload, not the verification
+        // wrapper; unwrap the sealed delivery type. Production code MUST
+        // exhaustively handle both Verified and Unverified — these tests
+        // only exercise the Verified path because they construct messages
+        // signed by known identities (no Unverified state reachable here).
+        router.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> received.add(delivery.message)
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery in a test that should only " +
+                        "produce verified messages — sender's identity should have been " +
+                        "registered with receiver's RNS via Identity.remember(). " +
+                        "Reason: ${delivery.reason}, source: ${delivery.message.sourceHash.toHexString()}"
+                )
+            }
+        }
 
         val destinationIdentity = Identity.create()
         router.registerDeliveryIdentity(destinationIdentity, "ResourceNode")
@@ -854,7 +899,22 @@ class LXMRouterTest {
         // layer reuses a buffer for receivingInterfaceHash, mutations must
         // not reach the LXMessage after delivery.
         val received = CopyOnWriteArrayList<LXMessage>()
-        router.registerDeliveryCallback { received.add(it) }
+        // Tests assert on the LXMessage payload, not the verification
+        // wrapper; unwrap the sealed delivery type. Production code MUST
+        // exhaustively handle both Verified and Unverified — these tests
+        // only exercise the Verified path because they construct messages
+        // signed by known identities (no Unverified state reachable here).
+        router.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> received.add(delivery.message)
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery in a test that should only " +
+                        "produce verified messages — sender's identity should have been " +
+                        "registered with receiver's RNS via Identity.remember(). " +
+                        "Reason: ${delivery.reason}, source: ${delivery.message.sourceHash.toHexString()}"
+                )
+            }
+        }
 
         val destinationIdentity = Identity.create()
         val deliveryDest = router.registerDeliveryIdentity(destinationIdentity, "DefensiveCopyNode")
@@ -891,7 +951,22 @@ class LXMRouterTest {
         // NULL metadata on the LXMessage — not garbage / zeros. This pins
         // the "null-or-meaningful" invariant downstream consumers rely on.
         val received = CopyOnWriteArrayList<LXMessage>()
-        router.registerDeliveryCallback { received.add(it) }
+        // Tests assert on the LXMessage payload, not the verification
+        // wrapper; unwrap the sealed delivery type. Production code MUST
+        // exhaustively handle both Verified and Unverified — these tests
+        // only exercise the Verified path because they construct messages
+        // signed by known identities (no Unverified state reachable here).
+        router.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> received.add(delivery.message)
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery in a test that should only " +
+                        "produce verified messages — sender's identity should have been " +
+                        "registered with receiver's RNS via Identity.remember(). " +
+                        "Reason: ${delivery.reason}, source: ${delivery.message.sourceHash.toHexString()}"
+                )
+            }
+        }
 
         val destinationIdentity = Identity.create()
         val deliveryDest = router.registerDeliveryIdentity(destinationIdentity, "MetaNodeNull")

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMessageDeliveryTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMessageDeliveryTest.kt
@@ -1,0 +1,114 @@
+package network.reticulum.lxmf
+
+import network.reticulum.common.DestinationDirection
+import network.reticulum.common.DestinationType
+import network.reticulum.destination.Destination
+import network.reticulum.identity.Identity
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the [LXMessageDelivery] sealed type and its
+ * dispatch surface in the registerDeliveryCallback API.
+ *
+ * Companion to the port-deviation entry "registerDeliveryCallback uses
+ * sealed LXMessageDelivery instead of raw LXMessage" — these tests
+ * exist to lock in the contract that the sealed type cannot be
+ * silently collapsed by callers and that Verified vs Unverified
+ * dispatch correctly.
+ */
+class LXMessageDeliveryTest {
+
+    private fun makeMessage(): LXMessage {
+        val srcIdentity = Identity.create()
+        val dstIdentity = Identity.create()
+        val srcDest = Destination.create(
+            identity = srcIdentity,
+            direction = DestinationDirection.IN,
+            type = DestinationType.SINGLE,
+            appName = "lxmf",
+            aspects = arrayOf("delivery"),
+        )
+        val dstDest = Destination.create(
+            identity = dstIdentity,
+            direction = DestinationDirection.OUT,
+            type = DestinationType.SINGLE,
+            appName = "lxmf",
+            aspects = arrayOf("delivery"),
+        )
+        return LXMessage.create(
+            destination = dstDest,
+            source = srcDest,
+            content = "test",
+            title = "t",
+        )
+    }
+
+    @Test
+    fun `Verified exposes the wrapped message via the abstract property`() {
+        val msg = makeMessage()
+        val delivery: LXMessageDelivery = LXMessageDelivery.Verified(msg)
+        assertSame(msg, delivery.message)
+    }
+
+    @Test
+    fun `Unverified exposes both the message and the reason`() {
+        val msg = makeMessage()
+        val delivery: LXMessageDelivery = LXMessageDelivery.Unverified(
+            message = msg,
+            reason = UnverifiedReason.SOURCE_UNKNOWN,
+        )
+        assertSame(msg, delivery.message)
+        assertEquals(UnverifiedReason.SOURCE_UNKNOWN, (delivery as LXMessageDelivery.Unverified).reason)
+    }
+
+    @Test
+    fun `exhaustive when over Verified and Unverified compiles and dispatches both branches`() {
+        // Compile-time proof: this `when` has no `else` branch, which means
+        // kotlin's exhaustiveness check confirmed the sealed type has no
+        // other subtypes. If a third subtype is ever added without
+        // updating callers, the consumer's `when` becomes a compile error
+        // — that's the entire point of using a sealed type for this
+        // security-sensitive API.
+        val branches = mutableListOf<String>()
+
+        fun route(delivery: LXMessageDelivery) {
+            when (delivery) {
+                is LXMessageDelivery.Verified -> branches.add("verified")
+                is LXMessageDelivery.Unverified -> branches.add("unverified:${delivery.reason}")
+            }
+        }
+
+        route(LXMessageDelivery.Verified(makeMessage()))
+        route(LXMessageDelivery.Unverified(makeMessage(), UnverifiedReason.SOURCE_UNKNOWN))
+        route(LXMessageDelivery.Unverified(makeMessage(), UnverifiedReason.SIGNATURE_INVALID))
+
+        assertEquals(
+            listOf("verified", "unverified:SOURCE_UNKNOWN", "unverified:SIGNATURE_INVALID"),
+            branches,
+            "All three deliveries must dispatch through their correct sealed-type branches in order",
+        )
+    }
+
+    @Test
+    fun `data class equality covers wrapper equivalence`() {
+        // Sanity for callers that put deliveries in collections / use them
+        // as map keys. data class equality uses the wrapped message's
+        // referential identity (LXMessage doesn't override equals), so two
+        // wrappers around the same message instance are equal.
+        val msg = makeMessage()
+        val a: LXMessageDelivery = LXMessageDelivery.Verified(msg)
+        val b: LXMessageDelivery = LXMessageDelivery.Verified(msg)
+        assertEquals(a, b)
+
+        val u1: LXMessageDelivery = LXMessageDelivery.Unverified(msg, UnverifiedReason.SOURCE_UNKNOWN)
+        val u2: LXMessageDelivery = LXMessageDelivery.Unverified(msg, UnverifiedReason.SOURCE_UNKNOWN)
+        assertEquals(u1, u2)
+
+        // Verified and Unverified wrapping the same message are NOT equal
+        // — different sealed-type branches must compare distinct.
+        assertTrue(a != u1, "Verified and Unverified must be distinct even with the same message")
+    }
+}

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMessageDeliveryTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMessageDeliveryTest.kt
@@ -6,6 +6,7 @@ import network.reticulum.destination.Destination
 import network.reticulum.identity.Identity
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -72,6 +73,12 @@ class LXMessageDeliveryTest {
         // updating callers, the consumer's `when` becomes a compile error
         // — that's the entire point of using a sealed type for this
         // security-sensitive API.
+        //
+        // Only SOURCE_UNKNOWN is exercised in the Unverified branch:
+        // SIGNATURE_INVALID is rejected at construction by the
+        // Unverified `init` guard (separate test below) since the router
+        // drops it before wrapping. Constructing it here would only
+        // normalise a state the API contract says is impossible.
         val branches = mutableListOf<String>()
 
         fun route(delivery: LXMessageDelivery) {
@@ -83,12 +90,29 @@ class LXMessageDeliveryTest {
 
         route(LXMessageDelivery.Verified(makeMessage()))
         route(LXMessageDelivery.Unverified(makeMessage(), UnverifiedReason.SOURCE_UNKNOWN))
-        route(LXMessageDelivery.Unverified(makeMessage(), UnverifiedReason.SIGNATURE_INVALID))
 
         assertEquals(
-            listOf("verified", "unverified:SOURCE_UNKNOWN", "unverified:SIGNATURE_INVALID"),
+            listOf("verified", "unverified:SOURCE_UNKNOWN"),
             branches,
-            "All three deliveries must dispatch through their correct sealed-type branches in order",
+            "Both deliveries must dispatch through their correct sealed-type branches in order",
+        )
+    }
+
+    @Test
+    fun `Unverified rejects SIGNATURE_INVALID at construction`() {
+        // The Unverified.init guard makes the documented invariant
+        // structural: SIGNATURE_INVALID is dropped at the router layer
+        // (LXMRouter.processInboundDelivery) and must never be wrapped
+        // in an Unverified delivery. This test is the type-system
+        // counterpart to the router-layer drop tested in LXMRouterTest
+        // — together they enforce the invariant at both ends of the
+        // delivery pipeline.
+        val ex = assertFailsWith<IllegalArgumentException> {
+            LXMessageDelivery.Unverified(makeMessage(), UnverifiedReason.SIGNATURE_INVALID)
+        }
+        assertTrue(
+            ex.message?.contains("SIGNATURE_INVALID") == true,
+            "Failure message must reference SIGNATURE_INVALID for diagnosability; got: ${ex.message}",
         )
     }
 

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/LiveDeliveryTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/LiveDeliveryTest.kt
@@ -10,6 +10,7 @@ import network.reticulum.interop.getString
 import network.reticulum.lxmf.DeliveryMethod
 import network.reticulum.lxmf.LXMFConstants
 import network.reticulum.lxmf.LXMessage
+import network.reticulum.lxmf.LXMessageDelivery
 import network.reticulum.lxmf.MessageState
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -31,10 +32,27 @@ class LiveDeliveryTest : DirectDeliveryTestBase() {
     private val receivedMessages = CopyOnWriteArrayList<LXMessage>()
 
     private fun registerDeliveryCallback() {
-        // Register delivery callback for Python -> Kotlin messages
-        kotlinRouter.registerDeliveryCallback { message ->
-            println("[KT] Received message: ${message.title} - ${message.content}")
-            receivedMessages.add(message)
+        // Register delivery callback for Python -> Kotlin messages.
+        // The python sender's identity is shared with this kotlin receiver
+        // via the Identity.remember setup in DirectDeliveryTestBase, so
+        // every delivery here should arrive Verified. An Unverified
+        // delivery in this fixture is a test setup bug, not a production
+        // signature failure — fail loudly so the misconfiguration is
+        // visible rather than silently degrading the assertion target.
+        kotlinRouter.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> {
+                    val message = delivery.message
+                    println("[KT] Received message: ${message.title} - ${message.content}")
+                    receivedMessages.add(message)
+                }
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery from python in DirectDelivery " +
+                        "fixture — python sender's identity should have been registered " +
+                        "with the kotlin receiver via Identity.remember(). " +
+                        "Reason: ${delivery.reason}"
+                )
+            }
         }
     }
 

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/PropagatedDeliveryTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/PropagatedDeliveryTest.kt
@@ -17,6 +17,7 @@ import network.reticulum.interop.getString
 import network.reticulum.lxmf.DeliveryMethod
 import network.reticulum.lxmf.LXMFConstants
 import network.reticulum.lxmf.LXMessage
+import network.reticulum.lxmf.LXMessageDelivery
 import network.reticulum.lxmf.LXStamper
 import network.reticulum.lxmf.MessageState
 import org.junit.jupiter.api.Test
@@ -45,9 +46,19 @@ class PropagatedDeliveryTest : PropagatedDeliveryTestBase() {
 
     private fun registerDeliveryCallback() {
         receivedMessages.clear()
-        kotlinRouter.registerDeliveryCallback { message ->
-            println("[KT] Received message via delivery callback: ${message.title} - ${message.content}")
-            receivedMessages.add(message)
+        kotlinRouter.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> {
+                    val message = delivery.message
+                    println("[KT] Received message via delivery callback: ${message.title} - ${message.content}")
+                    receivedMessages.add(message)
+                }
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery from python — sender's identity should " +
+                        "have been registered with kotlin receiver via Identity.remember(). " +
+                        "Reason: ${delivery.reason}"
+                )
+            }
         }
     }
 

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/PythonToKotlinOpportunisticTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/PythonToKotlinOpportunisticTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import network.reticulum.interop.getString
 import network.reticulum.lxmf.LXMFConstants
 import network.reticulum.lxmf.LXMessage
+import network.reticulum.lxmf.LXMessageDelivery
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.util.concurrent.CopyOnWriteArrayList
@@ -30,9 +31,18 @@ class PythonToKotlinOpportunisticTest : OpportunisticDeliveryTestBase() {
         receivedMessages.clear()
 
         // Set up Kotlin to receive messages
-        kotlinRouter.registerDeliveryCallback { message ->
-            println("[Test] Kotlin received message: ${message.content}")
-            receivedMessages.add(message)
+        kotlinRouter.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> {
+                    val message = delivery.message
+                    println("[Test] Kotlin received message: ${message.content}")
+                    receivedMessages.add(message)
+                }
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery — sender's identity should " +
+                        "have been registered with kotlin receiver. Reason: ${delivery.reason}"
+                )
+            }
         }
 
         // Step 1: Kotlin announces so Python knows the path and can recall identity
@@ -84,8 +94,13 @@ class PythonToKotlinOpportunisticTest : OpportunisticDeliveryTestBase() {
     fun `Python opportunistic message with fields preserved`() = runBlocking {
         receivedMessages.clear()
 
-        kotlinRouter.registerDeliveryCallback { message ->
-            receivedMessages.add(message)
+        kotlinRouter.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> receivedMessages.add(delivery.message)
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery. Reason: ${delivery.reason}"
+                )
+            }
         }
 
         // Kotlin announces
@@ -134,8 +149,13 @@ class PythonToKotlinOpportunisticTest : OpportunisticDeliveryTestBase() {
     fun `Python opportunistic message title preserved`() = runBlocking {
         receivedMessages.clear()
 
-        kotlinRouter.registerDeliveryCallback { message ->
-            receivedMessages.add(message)
+        kotlinRouter.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> receivedMessages.add(delivery.message)
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery. Reason: ${delivery.reason}"
+                )
+            }
         }
 
         // Kotlin announces

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ResourceDeliveryTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ResourceDeliveryTest.kt
@@ -10,6 +10,7 @@ import network.reticulum.interop.getString
 import network.reticulum.lxmf.DeliveryMethod
 import network.reticulum.lxmf.LXMFConstants
 import network.reticulum.lxmf.LXMessage
+import network.reticulum.lxmf.LXMessageDelivery
 import network.reticulum.lxmf.MessageRepresentation
 import network.reticulum.lxmf.MessageState
 import org.junit.jupiter.api.MethodOrderer
@@ -44,9 +45,18 @@ class ResourceDeliveryTest : DirectDeliveryTestBase() {
     private val receivedMessages = CopyOnWriteArrayList<LXMessage>()
 
     private fun registerDeliveryCallback() {
-        kotlinRouter.registerDeliveryCallback { message ->
-            println("[KT] Received message: ${message.title} - ${message.content.take(50)}...")
-            receivedMessages.add(message)
+        kotlinRouter.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified -> {
+                    val message = delivery.message
+                    println("[KT] Received message: ${message.title} - ${message.content.take(50)}...")
+                    receivedMessages.add(message)
+                }
+                is LXMessageDelivery.Unverified -> error(
+                    "test setup bug: unverified delivery from python sender. " +
+                        "Reason: ${delivery.reason}"
+                )
+            }
         }
     }
 

--- a/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/DeliveryConfirmTest.kt
+++ b/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/DeliveryConfirmTest.kt
@@ -11,6 +11,7 @@ import network.reticulum.interfaces.tcp.TCPClientInterface
 import network.reticulum.interfaces.toRef
 import network.reticulum.lxmf.DeliveryMethod
 import network.reticulum.lxmf.LXMessage
+import network.reticulum.lxmf.LXMessageDelivery
 import network.reticulum.lxmf.LXMRouter
 import network.reticulum.lxmf.MessageState
 import network.reticulum.transport.Transport
@@ -90,8 +91,13 @@ class DeliveryConfirmTest {
         myDestination = router.registerDeliveryIdentity(identity, "Delivery Test Client")
 
         // Register callback for incoming messages (echoes)
-        router.registerDeliveryCallback { message ->
-            log("Received echo: ${message.content}")
+        router.registerDeliveryCallback { delivery ->
+            when (delivery) {
+                is LXMessageDelivery.Verified ->
+                    log("Received echo: ${delivery.message.content}")
+                is LXMessageDelivery.Unverified ->
+                    log("Received UNVERIFIED echo (${delivery.reason}): ${delivery.message.content}")
+            }
         }
 
         router.start()

--- a/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/LxmfEchoBot.kt
+++ b/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/LxmfEchoBot.kt
@@ -12,6 +12,7 @@ import network.reticulum.interfaces.tcp.TCPServerInterface
 import network.reticulum.interfaces.toRef
 import network.reticulum.lxmf.DeliveryMethod
 import network.reticulum.lxmf.LXMessage
+import network.reticulum.lxmf.LXMessageDelivery
 import network.reticulum.lxmf.LXMRouter
 import network.reticulum.transport.Transport
 import java.time.Instant
@@ -120,8 +121,20 @@ class LxmfEchoBot {
         myDestination = router.registerDeliveryIdentity(identity, DISPLAY_NAME)
 
         // Register callback for incoming messages
-        router.registerDeliveryCallback { message ->
-            handleIncomingMessage(message)
+        router.registerDeliveryCallback { delivery ->
+            // Echo bot policy: only echo verified messages. Echoing
+            // unverified messages would let an unverified peer trigger
+            // outbound traffic by claiming to be from a known sender,
+            // which has DDoS-amplification potential.
+            when (delivery) {
+                is LXMessageDelivery.Verified -> handleIncomingMessage(delivery.message)
+                is LXMessageDelivery.Unverified -> {
+                    System.err.println(
+                        "[WARN] Dropping unverified message from " +
+                            "${delivery.message.sourceHash.toHexString()}: ${delivery.reason}"
+                    )
+                }
+            }
         }
 
         // Start the router's background processing

--- a/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/LxmfNode.kt
+++ b/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/LxmfNode.kt
@@ -7,6 +7,7 @@ import network.reticulum.identity.Identity
 import network.reticulum.interfaces.toRef
 import network.reticulum.interfaces.udp.UDPInterface
 import network.reticulum.lxmf.LXMessage
+import network.reticulum.lxmf.LXMessageDelivery
 import network.reticulum.lxmf.LXMRouter
 import network.reticulum.transport.Transport
 import java.time.Instant
@@ -134,8 +135,19 @@ class LxmfNode(
         val destination = router.registerDeliveryIdentity(identity, displayName)
 
         // Register callback for incoming messages
-        router.registerDeliveryCallback { message ->
-            handleIncomingMessage(message)
+        router.registerDeliveryCallback { delivery ->
+            // Demo policy: ingest both, distinguish in the log line.
+            // Production consumers should pick a stricter policy.
+            when (delivery) {
+                is LXMessageDelivery.Verified -> handleIncomingMessage(delivery.message)
+                is LXMessageDelivery.Unverified -> {
+                    System.err.println(
+                        "[WARN] Unverified message from " +
+                            "${delivery.message.sourceHash.toHexString()}: ${delivery.reason}"
+                    )
+                    handleIncomingMessage(delivery.message)
+                }
+            }
         }
 
         // Start the router's background processing

--- a/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/LxmfSender.kt
+++ b/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/LxmfSender.kt
@@ -11,6 +11,7 @@ import network.reticulum.interfaces.tcp.TCPClientInterface
 import network.reticulum.interfaces.toRef
 import network.reticulum.lxmf.DeliveryMethod
 import network.reticulum.lxmf.LXMessage
+import network.reticulum.lxmf.LXMessageDelivery
 import network.reticulum.lxmf.LXMRouter
 import network.reticulum.transport.Transport
 import java.time.Instant
@@ -128,8 +129,25 @@ class LxmfSender(
         myDestination = router.registerDeliveryIdentity(identity, DISPLAY_NAME)
 
         // Register for incoming messages (echo replies)
-        router.registerDeliveryCallback { message ->
-            handleIncomingMessage(message)
+        router.registerDeliveryCallback { delivery ->
+            // Realistic example policy mirroring Sideband's UI behavior:
+            // ingest both verified and unverified messages, but log a
+            // warning for unverified ones so a downstream UI can render
+            // a "this sender is unverified" badge. Replace with strict
+            // drop in production if you don't want unverified messages
+            // visible at all.
+            when (delivery) {
+                is LXMessageDelivery.Verified ->
+                    handleIncomingMessage(delivery.message)
+                is LXMessageDelivery.Unverified -> {
+                    System.err.println(
+                        "[WARN] Unverified message from " +
+                            "${delivery.message.sourceHash.toHexString()}: " +
+                            "${delivery.reason} — treat with caution"
+                    )
+                    handleIncomingMessage(delivery.message)
+                }
+            }
         }
 
         router.start()

--- a/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/PropagationSyncTest.kt
+++ b/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/PropagationSyncTest.kt
@@ -5,6 +5,7 @@ import network.reticulum.common.toHexString
 import network.reticulum.identity.Identity
 import network.reticulum.interfaces.tcp.TCPClientInterface
 import network.reticulum.interfaces.toRef
+import network.reticulum.lxmf.LXMessageDelivery
 import network.reticulum.lxmf.LXMRouter
 import network.reticulum.lxmf.LXMRouter.PropagationTransferState
 import network.reticulum.transport.Transport
@@ -101,12 +102,19 @@ class PropagationSyncTest {
         println("Registered delivery destination: ${deliveryDest.hash.toHexString()}")
 
         // Register message callback
-        router.registerDeliveryCallback { message ->
+        router.registerDeliveryCallback { delivery ->
+            // Unwrap the sealed delivery type. Test instrumentation
+            // tracks valid-vs-invalid counts separately so the test
+            // can assert on signature validation behavior end-to-end.
+            val message = delivery.message
+            val isValidated = delivery is LXMessageDelivery.Verified
+            val unverifiedReasonText = (delivery as? LXMessageDelivery.Unverified)?.reason?.toString()
+
             messagesReceived++
             val msgSenderHash = message.sourceHash?.toHexString() ?: "unknown"
             if (senderHash == null) senderHash = msgSenderHash
 
-            if (message.signatureValidated) {
+            if (isValidated) {
                 signaturesValid.incrementAndGet()
             } else {
                 signaturesInvalid.incrementAndGet()
@@ -118,9 +126,9 @@ class PropagationSyncTest {
             println("From: $msgSenderHash")
             println("Title: ${message.title}")
             println("Content: ${message.content}")
-            println("Signature valid: ${message.signatureValidated}")
-            if (!message.signatureValidated) {
-                println("Unverified reason: ${message.unverifiedReason}")
+            println("Signature valid: $isValidated")
+            if (unverifiedReasonText != null) {
+                println("Unverified reason: $unverifiedReasonText")
             }
             println("${"=".repeat(50)}\n")
         }

--- a/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/PropagationSyncTest.kt
+++ b/lxmf-examples/src/main/kotlin/network/reticulum/lxmf/examples/PropagationSyncTest.kt
@@ -103,22 +103,23 @@ class PropagationSyncTest {
 
         // Register message callback
         router.registerDeliveryCallback { delivery ->
-            // Unwrap the sealed delivery type. Test instrumentation
-            // tracks valid-vs-invalid counts separately so the test
-            // can assert on signature validation behavior end-to-end.
+            // Unwrap the sealed delivery type via an exhaustive `when`
+            // so a future third subtype of LXMessageDelivery becomes a
+            // compile error here rather than silently misclassifying as
+            // signaturesInvalid — which is the exact silent-accept bug
+            // the sealed type is designed to prevent.
             val message = delivery.message
-            val isValidated = delivery is LXMessageDelivery.Verified
-            val unverifiedReasonText = (delivery as? LXMessageDelivery.Unverified)?.reason?.toString()
-
-            messagesReceived++
             val msgSenderHash = message.sourceHash?.toHexString() ?: "unknown"
             if (senderHash == null) senderHash = msgSenderHash
+            messagesReceived++
 
-            if (isValidated) {
-                signaturesValid.incrementAndGet()
-            } else {
-                signaturesInvalid.incrementAndGet()
+            when (delivery) {
+                is LXMessageDelivery.Verified -> signaturesValid.incrementAndGet()
+                is LXMessageDelivery.Unverified -> signaturesInvalid.incrementAndGet()
             }
+
+            val isValidated = delivery is LXMessageDelivery.Verified
+            val unverifiedReasonText = (delivery as? LXMessageDelivery.Unverified)?.reason?.toString()
 
             println("\n${"=".repeat(50)}")
             println("MESSAGE RECEIVED (#$messagesReceived)")

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -12,6 +12,8 @@ This file is the **single source of truth** for every place where LXMF-kt's logi
 
 **Allowed reason 3 — Deferred python feature.** A python feature that the port has not yet implemented. The port's downstream consumers MUST NOT rely on the missing behavior, and the gap MUST be documented here so that (a) reviewers don't silently re-implement it incorrectly, (b) cross-impl conformance tests covering the missing path know to skip the kotlin axis (`pytest.mark.skipif(impl == "kotlin", reason=...)`), and (c) the gap shows up in any LXMF-kt feature-completeness audit. Removing a category-3 entry is itself the closing PR — the entry stays here only as long as the gap exists.
 
+**Allowed reason 4 — Safety-strict default.** The kotlin port enforces a stricter default than python at the library layer for a documented security reason. Used when python delegates a security-sensitive policy decision to consumers (typical pattern: report a flag, let the consumer act), but every known consumer either gets the policy wrong or omits it entirely, AND the kotlin type system can prevent the failure mode at compile time. The deviation MUST cite (a) the python reference site, (b) the failure mode being prevented, and (c) why type-system enforcement is preferable to documentation/convention. Wire-format compatibility MUST be preserved — these deviations only affect kotlin-side API surface and library-internal policy, never the bytes on the wire. Cross-impl conformance tests MUST still pass; if a test fails because of the kotlin stricter behavior, that's a signal the test was probing the unsafe path and should be reframed.
+
 ## Process
 
 1. Before changing a kotlin port file in a way that diverges from the python reference, read the corresponding python source.
@@ -26,7 +28,7 @@ This file is the **single source of truth** for every place where LXMF-kt's logi
 
 **Python reference:** `<path>:<line>` (e.g. `LXMF/LXMRouter.py:2554-2580`)
 
-**Category:** language/runtime forced  |  new feature  |  deferred python feature
+**Category:** language/runtime forced  |  new feature  |  deferred python feature  |  safety-strict default
 
 **Date:** YYYY-MM-DD
 
@@ -69,3 +71,72 @@ The kotlin port:
 2. Add `generateStamp(material, cost, expandRounds)` overload accepting custom expand rounds (mirror python `LXStamper.py:59`)
 3. Wire into `LXMPeer.kt` peering handshake mirroring `LXMPeer.py:259`
 4. Remove this entry; the closing PR lands the conformance test as well
+
+### LXMRouter drops messages with SIGNATURE_INVALID at the library layer — `lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt:1515-1518`
+
+**Python reference:** `LXMF/LXMF/LXMRouter.py:1714-1799` (`lxmf_delivery`). Python decodes the message via `LXMessage.unpack_from_bytes`, sets `message.signature_validated = False` and `message.unverified_reason = LXMessage.SIGNATURE_INVALID` (LXMessage.py:792-796), and **calls `self.__delivery_callback(message)` regardless** (LXMRouter.py:1787-1792). Python treats the signature-validity flag as informational metadata that consumers are expected to act on.
+
+**Category:** safety-strict default
+
+**Date:** 2026-04-30
+
+**Tracking:** signature-forgery POC at `/tmp/lxmf_signature_forgery_poc.py` (local — not checked in); reproduces against unmodified python LXMF and confirms the library delivers a forged message with `signature_validated = False` to the consumer callback.
+
+**Description:**
+The kotlin port adds an explicit drop at `processInboundDelivery` for `UnverifiedReason.SIGNATURE_INVALID`:
+
+```kotlin
+if (!message.signatureValidated) {
+    when (message.unverifiedReason) {
+        UnverifiedReason.SOURCE_UNKNOWN -> {
+            // Source not known — could still accept depending on policy
+            println("Message from unknown source: ${message.sourceHash.toHexString()}")
+        }
+        UnverifiedReason.SIGNATURE_INVALID -> {
+            println("Message signature invalid, rejecting")
+            return
+        }
+        ...
+    }
+}
+```
+
+`SIGNATURE_INVALID` only fires when the source identity IS known to the receiver (so the receiver had a public key to validate against) AND the signature did NOT validate against that key — i.e. the "tampered message claiming to be from a known sender" case. There is no legitimate scenario where this should reach the consumer; the only reason python passes it through is the python LXMF library's design choice to delegate policy to consumers.
+
+**Failure mode being prevented:**
+A consumer that doesn't filter `signature_validated == False` (verified empirically: Columba's main-branch app code has zero references to `signatureValidated`) renders forged messages as authentic. The forgery POC demonstrates this against python LXMF; the kotlin library's drop closes the equivalent attack vector at the library layer for any LXMF-kt consumer.
+
+**Why type-system enforcement is preferable:**
+The complementary `SOURCE_UNKNOWN` case (legitimate first-contact from a sender whose announce hasn't propagated) cannot be dropped at the library layer — it represents real messages that the consumer might want to deliver-with-warning. Those reach the consumer wrapped in [LXMessageDelivery.Unverified] (separate deviation entry below) so kotlin's exhaustive `when` forces an explicit policy decision. The combination — drop `SIGNATURE_INVALID` at the library, force consumer to handle `SOURCE_UNKNOWN` at the API surface — covers the entire signature-forgery class without losing legitimate first-contact messages.
+
+**Wire compatibility:** unchanged. The kotlin library still decodes the wire bytes, still sets `signatureValidated = False`, still records `unverifiedReason = SIGNATURE_INVALID`. Only the post-decode policy differs.
+
+**Re-evaluation:** if upstream python LXMF adds a `router.enforce_signature` config option (or similar) that drops `SIGNATURE_INVALID` at the library layer, this deviation becomes "matching upstream's default" and can be removed — though the current behavior should remain as the kotlin default regardless of upstream's choice.
+
+### registerDeliveryCallback uses sealed `LXMessageDelivery` instead of raw `LXMessage` — `lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt:451`
+
+**Python reference:** `LXMF/LXMF/LXMRouter.py:356-357` — `register_delivery_callback(self, callback)`; the callback receives a single positional argument `(LXMessage)` and is expected to read `message.signature_validated` to decide policy.
+
+**Category:** safety-strict default
+
+**Date:** 2026-04-30
+
+**Tracking:** companion to the `SIGNATURE_INVALID` drop entry above. New file `LXMessageDelivery.kt` defines the sealed type.
+
+**Description:**
+The kotlin port's `registerDeliveryCallback` takes a `(LXMessageDelivery) -> Unit` instead of a `(LXMessage) -> Unit`. `LXMessageDelivery` is a sealed class with two subtypes:
+
+  - `LXMessageDelivery.Verified(message)` — signature was checked and valid against a known source identity
+  - `LXMessageDelivery.Unverified(message, reason)` — signature could not be verified; reason is always `UnverifiedReason.SOURCE_UNKNOWN` because the SIGNATURE_INVALID case is dropped at the library layer (separate deviation above)
+
+Consumers MUST exhaustively handle both subtypes — kotlin's `when` exhaustiveness check on a sealed type is a compile error if either branch is omitted.
+
+**Failure mode being prevented:**
+The python single-callback signature lets the consumer ignore `signature_validated` silently (Columba is the empirical example). The kotlin sealed-type signature makes that ignoring impossible at compile time — the consumer is forced to write a code path for the Unverified branch even if that path is "drop and log" or "ingest with warning".
+
+**Why type-system enforcement is preferable:**
+Documentation and convention have demonstrably failed (Columba). The kotlin compiler can prevent the failure mode mechanically with no runtime cost and no behavior change for correctly-implemented consumers — the Verified branch handles the same messages a python consumer would see in the all-validated case.
+
+**Wire compatibility:** unchanged. LXMessage decoding and the LXMF wire format are untouched. This is purely a kotlin API surface decision.
+
+**Re-evaluation:** unconditionally keep. If upstream python LXMF ever adopts a similar sum-typed callback (e.g. via a Result wrapper) for the same reason, the categorization could shift to "matching upstream", but the kotlin behavior should remain regardless.

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -80,7 +80,7 @@ The kotlin port:
 
 **Date:** 2026-04-30
 
-**Tracking:** signature-forgery POC at `/tmp/lxmf_signature_forgery_poc.py` (local — not checked in); reproduces against unmodified python LXMF and confirms the library delivers a forged message with `signature_validated = False` to the consumer callback.
+**Tracking:** signature-forgery technique reproduced against unmodified python LXMF. Procedure: (a) read the recipient's announce off the network — this exposes the recipient identity public key + destination hash; (b) construct an `LXMessage` addressed to the recipient with an attacker-chosen `source_hash` referencing some other known identity; (c) encrypt the packet to the recipient's public key (the recipient's identity public key is by-design public, distributed via announces); (d) sign with the attacker's own private key, not the impersonated source's; (e) deliver via standard RNS transport. The recipient decodes the packet, sets `message.signature_validated = False` and `message.unverified_reason = SIGNATURE_INVALID` (because the `source_hash` matches a known identity but the signature did not validate against that identity's public key), and python LXMF unconditionally calls `__delivery_callback(message)` regardless (LXMRouter.py:1787-1792). A consumer that does not filter on `signature_validated` then renders the forged message as authentic. The kotlin port closes this at the library layer by dropping `SIGNATURE_INVALID` before the callback is invoked.
 
 **Description:**
 The kotlin port adds an explicit drop at `processInboundDelivery` for `UnverifiedReason.SIGNATURE_INVALID`:


### PR DESCRIPTION
## Summary

Adds a kotlin-only safety wrapper that prevents the entire signature-forgery class of bugs at compile time, regardless of consumer discipline.

## Background

A signature-forgery POC against unmodified python LXMF confirmed that the library calls the consumer's delivery callback even when `signature_validated` is False. Sideband mitigates app-side; **Columba's main-branch app code has zero references to `signatureValidated`**, so any unverified message that LXMF-kt passes through is rendered as authentic in Columba's UI.

LXMF-kt today partially mitigates: `LXMRouter.processInboundDelivery` already drops `UnverifiedReason.SIGNATURE_INVALID` (the "tampered message claiming to be from a known sender" case). But `UnverifiedReason.SOURCE_UNKNOWN` (the "I've never seen this sender's identity announce" case — also forgeable by anyone who generates a fresh identity hash) flows through to consumers without a compile-time gate.

## What this PR does

1. New sealed type `LXMessageDelivery`:
   - `Verified(message)` — signature checked against known source
   - `Unverified(message, reason)` — only `SOURCE_UNKNOWN` reachable since `SIGNATURE_INVALID` is dropped earlier

2. Changes `registerDeliveryCallback` from `(LXMessage) -> Unit` to `(LXMessageDelivery) -> Unit`. Kotlin's exhaustive `when` on a sealed type makes silent-accept-unverified a compile error rather than a code-review hope.

3. Wraps the message at the existing invocation site (no behavior change for consumers that handle both branches — Verified branch sees exactly what the old single-callback API delivered).

## Port-deviations documented

Two new entries plus a new "safety-strict default" allowed-reason category in the framework:

| Deviation | Category |
|---|---|
| `LXMRouter.kt:1515-1518` SIGNATURE_INVALID drop (pre-existing, now formally documented) | safety-strict default |
| `LXMRouter.kt:451 registerDeliveryCallback` sealed-type API (new in this PR) | safety-strict default |

The new "safety-strict default" category (allowed reason 4) requires citing the python reference site, the failure mode prevented, and why type-system enforcement is preferable to documentation.

## Wire compatibility

Unchanged. LXMessage decoding, LXMRouter inbound packet processing, and on-the-wire bytes are untouched. Cross-impl interop with python LXMF and iOS LXMF is unaffected.

## Consumer migration

All in-tree consumers updated:
- `conformance-bridge`: unwraps the sealed type, exposes new `unverified` and `unverified_reason` JSON fields on inbox entries (unblocks lxmf-conformance#10 — signature tampering test surface)
- `lxmf-core` unit + interop tests: use strict pattern (Unverified arrival = test setup bug, fail loudly)
- `lxmf-examples`: realistic policies — LxmfSender / LxmfNode warn-and-ingest, LxmfEchoBot drops unverified to avoid DDoS-amplification

Out-of-tree consumer (Columba) follows in a separate PR with companion UI warning chip + Room migration.

## Test plan

- [x] Unit tests in new `LXMessageDeliveryTest.kt` cover sealed type construction, exhaustive `when` dispatch, and data-class equality
- [x] Existing `LXMRouterTest` passes with the new callback signature
- [x] `INCLUDE_CONFORMANCE_BRIDGE=1 ./gradlew :conformance-bridge:shadowJar` builds clean
- [x] lxmf-conformance regression: **12/12 wire-E2E tests pass cross-impl** (test_opportunistic, test_attachments, test_direct) — confirms the new bridge JSON fields are additive and don't break existing consumers

## Stack

Stacks on [#27](https://github.com/torlando-tech/LXMF-kt/pull/27) (port-deviations framework: adds "deferred python feature" category, which this PR's "safety-strict default" category extends). Recommended merge order: #27 → this PR. Then companion Columba PR.

---
🤖 Generated with claude-opus-4-7[1m]