### PR TITLE
ci(conformance): set INCLUDE_CONFORMANCE_BRIDGE=1 for the build step

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -106,6 +106,12 @@ jobs:
         # The bridge JAR ends up at conformance-bridge/build/libs/
         # LXMFConformanceBridge.jar — same path the conformance repo's
         # default detection looks at via CONFORMANCE_KOTLIN_BRIDGE_CMD.
+        # settings.gradle.kts gates :conformance-bridge behind this env var
+        # so Gradle 9 consumers (Columba) using composite-build override
+        # don't pick up the Shadow plugin transitively. Set it here so the
+        # bridge project actually exists when this workflow asks for it.
+        env:
+          INCLUDE_CONFORMANCE_BRIDGE: "1"
         run: ./gradlew :conformance-bridge:shadowJar --stacktrace
 
       - name: Run conformance suite (python ↔ kotlin)

--- a/lxmf-core/build.gradle.kts
+++ b/lxmf-core/build.gradle.kts
@@ -20,13 +20,13 @@ dependencies {
     // api scope: lxmf-core's public API (LXMRouter, LXMessage) exposes
     // rns-core types (Destination, Identity) as parameters and return types,
     // so consumers need rns-core on their compile classpath.
-    api("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.15")
+    api("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.17")
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
     // Test dependencies for live networking tests
-    testImplementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:v0.0.15")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:v0.0.17")
 
     // MessagePack for serialization (already in rns-core, but explicit)
     implementation("org.msgpack:msgpack-core:0.9.8")
@@ -43,7 +43,7 @@ dependencies {
     testRuntimeOnly("org.slf4j:slf4j-simple:2.0.9")
 
     // Interop testing - reuse Python bridge infrastructure from rns-test
-    testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:v0.0.15")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:v0.0.17")
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
     // Compression - Apache Commons Compress for BZ2 interop tests

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,4 +27,12 @@ rootProject.name = "lxmf-kt"
 
 include(":lxmf-core")
 include(":lxmf-examples")
-include(":conformance-bridge")
+
+// :conformance-bridge applies the Shadow plugin, which is incompatible with
+// Gradle 9. Columba consumes lxmf-kt via composite-build override on Gradle 9
+// and would inherit the Shadow plugin transitively if this project were always
+// included in the build. The conformance CI workflow sets INCLUDE_CONFORMANCE_BRIDGE=1
+// on the build step that needs it (see .github/workflows/conformance.yml).
+if (System.getenv("INCLUDE_CONFORMANCE_BRIDGE") != null) {
+    include(":conformance-bridge")
+}


### PR DESCRIPTION
## Summary

The conformance job has been failing with:

```
Cannot locate tasks that match ':conformance-bridge:shadowJar'
as project 'conformance-bridge' not found in root project 'lxmf-kt'.
```

`settings.gradle.kts` gates `:conformance-bridge` behind the `INCLUDE_CONFORMANCE_BRIDGE` env var so a Gradle 9 consumer (Columba) using composite-build override doesn't pull the Shadow plugin transitively. The workflow's `Build :conformance-bridge shadowJar` step then asks Gradle to build that exact project — without the env var, the project isn't included in the build and the step fails before any conformance tests run.

This sets the env var on just the build step so:
- The gating intent stays intact (Columba composite consumers still skip the Shadow-plugin path)
- The conformance job actually finds the project it's trying to build

## Test plan

- [ ] CI on this PR builds `:conformance-bridge:shadowJar` successfully
- [ ] Conformance suite (`pytest tests/ --impls python,kotlin`) actually runs after the build step
- [ ] No change to local `./gradlew :lxmf-core:test` flow (env var only set on the CI build step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)