### PR TITLE
fix(LXMRouter): identify on reused propagation link before /get

### DIFF
--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -2118,6 +2118,13 @@ class LXMRouter(
         println("[LXMRouter] requestMessages: link=${link != null}, status=${link?.status}, node=${node.hexHash.take(12)}")
         if (link != null && link.status == LinkConstants.ACTIVE) {
             propagationTransferState = PropagationTransferState.LINK_ESTABLISHED
+            // Mirror python LXMRouter.py:494 — identify on the link before
+            // requesting messages, even when reusing an existing one. The
+            // delivery path establishes a link without identifying, so a
+            // reused link won't be associated with our peer identity until
+            // we call identify here. Skipping this caused lxmd to return
+            // ERROR_NO_IDENTITY (240) on /get requests.
+            identifyOnLink(link)
             requestMessageList(link)
         } else {
             // Need to establish link first


### PR DESCRIPTION
## Summary

`requestMessagesFromPropagationNode` skipped `link.identify()` when reusing an active `outboundPropagationLink`. The python reference at `LXMRouter.py:494` always identifies before calling `link.request()`, even on the reuse path. The earlier delivery-path fix at b732373 deliberately leaves delivery links unidentified — so a link that was established for SEND but is now being reused for /get has no peer identity associated with it on the lxmd side.

lxmd correctly rejects with `ERROR_NO_IDENTITY` (0xf0 = 240) on every retry, exhausting all 3 attempts and leaving the retrieval state at FAILED.

## Reproducer

Columba phone harness, after a successful PROPAGATED upload via SEND_PROP:

```
SET_PROP_NODE → prop_node_set
SEND_PROP     → msg_state=PROPAGATED (lxmd messagestore += 1)
SYNC_PROP     → "Propagation node returned error 240, retrying (1/3)..."
                "Propagation node returned error 240, retrying (2/3)..."
                "Propagation node returned error 240, retrying (3/3)..."
                "Propagation node returned error 240 after 3 retries"
GET_RX        → rx_drain count=0
```

## Fix

Call `identifyOnLink(link)` before `requestMessageList(link)` on the reuse branch. Mirrors python LXMRouter.py:494.

## Verification

After the fix, on the same phone harness:

```
SYNC_PROP     → [LXMRouter] messageList response: size=69, hex=92c420...
                rx_msg from=06dad767... id=d584ade... content=OPT_…
                rx_msg from=06dad767... id=3c2d58c... content=BIDI_…
GET_RX        → rx_drain count=2
```

Both queued messages downloaded, decrypted, and surfaced via `messageReceivedFlow`. End-to-end PROPAGATED bidirectional now works against a real lxmd in <1s per message.

## Notes

- This was paired in the field with a Stamper perf fix in reticulum-kt (torlando-tech/reticulum-kt#66) — without that, the stamp gen at lxmd's default cost=16 took 21s and the link timed out before any /get could even be attempted. With both landed, columba PROPAGATED is fast enough to actually use.
- No port-deviations.md update needed — this is closing an existing divergence, not introducing one.

## Test plan

- [ ] CI green (existing LXMRouter tests cover happy-path retrieval; this exercises the reuse branch which was untested)
- [ ] Manual: bench against the phone harness (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)