### PR TITLE
fix(python-bridge): point symlink at sibling reticulum-kt checkout

### DIFF
--- a/python-bridge
+++ b/python-bridge
@@ -1,1 +1,1 @@
-reticulum-kt/python-bridge
+../reticulum-kt/python-bridge


### PR DESCRIPTION
## Summary

The committed `python-bridge` symlink target \`reticulum-kt/python-bridge\` resolves relative to \`LXMF-kt/\`, expecting \`LXMF-kt/reticulum-kt/python-bridge\` to exist. That subdirectory has never existed in this repo (no submodule, no setup script that creates it), so the symlink has been broken since the initial commit.

The consequence: every interop test in \`src/test/.../interop/\` fails locally with \"Bridge script not found\" before any test code executes. Only the \`conformance.yml\` CI passes because it builds the \`:conformance-bridge\` shadowJar and runs against an entirely separate pytest harness via \`CONFORMANCE_KOTLIN_BRIDGE_CMD\` — that path doesn't touch the symlink at all.

## The fix

Repoint the symlink to \`../reticulum-kt/python-bridge\`, the convention every dev with a sibling \`reticulum-kt\` checkout uses. This is what \`PythonBridge.kt\`'s walk-up search expects to find when running tests from \`\$PWD/lxmf-core/\`.

## Test plan

- [x] Local: \`./gradlew :lxmf-core:test --tests 'network.reticulum.lxmf.interop.MessageHashInteropTest' -PrunInteropTests=true\` — 8/8 pass after the fix (0 found before)
- [x] Local: \`StampInteropTest\` passes
- [x] CI \`tests.yml\` is unaffected — it excludes \`interop.**\` and never sets \`runInteropTests=true\`
- [x] CI \`conformance.yml\` is unaffected — uses \`:conformance-bridge:shadowJar\` + a separate harness, doesn't touch this symlink

## Why this matters now

Discovered while investigating a real Columba→Sideband \"invalid stamp\" bug. The interop test gap (no test stands up a stamp-enforcing receiver and verifies stamped wire bytes validate) lets the bug ship undetected. A follow-up PR adds \`StampedMessageDeliveryTest\` (15 tests) which proves the gap is real and reproduces the production failure — that PR can't be exercised locally without this symlink fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)