### PR TITLE
fix(conformance-bridge): implement lxmf_get_message_progress

### DIFF
--- a/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
+++ b/conformance-bridge/src/main/kotlin/network/reticulum/lxmf/conformance/Main.kt
@@ -705,6 +705,42 @@ private fun cmdLxmfGetReceivedMessages(params: JSONObject): JSONObject {
     return JSONObject().put("messages", out).put("last_seq", lastSeq)
 }
 
+/**
+ * Return resource-transfer progress for [message_hash] in [0.0, 1.0], or
+ * the -1.0 sentinel if untracked.
+ *
+ * Mirrors the python reference at
+ * `lxmf-conformance/reference/lxmf_python.py::cmd_lxmf_get_message_progress`,
+ * which itself mirrors microLXMF's `lxmf_get_message_progress`. Reads the
+ * public `LXMessage.progress` field (LXMessage.kt:142) — populated by
+ * `LXMRouter.sendViaLink`'s Resource progressCallback (LXMRouter.kt:1340)
+ * for messages that fall back to RNS Resource transfer (>319 B content).
+ *
+ * Resolution differs slightly from python:
+ *   - Python keeps a `_outbound_progress` snapshot map populated by the
+ *     state callback right before the live reference is popped from
+ *     `_outbound_messages` on terminal state, so polling tests can still
+ *     read 1.0 after `state == 'delivered'`.
+ *   - Kotlin never pops from `outboundMessages` until shutdown
+ *     (Main.kt:854 is the only `.clear()`), so the live reference itself
+ *     persists past delivery and `message.progress = 1.0` (set by the
+ *     completion callback at LXMRouter.kt:1335) survives the same poll
+ *     window. No separate snapshot map needed.
+ *
+ * Untracked = `message_hash` was never inserted into `outboundMessages`
+ * (e.g. send command never ran, or it failed before computing the hash).
+ * Small messages that took the PACKET path are NOT untracked here — they
+ * return 0.0 (the `LXMessage.progress` default), which the test accepts
+ * as a valid "no Resource ticks happened" sample (≥0 passes its filter).
+ */
+private fun cmdLxmfGetMessageProgress(params: JSONObject): JSONObject {
+    ensureRouter("lxmf_get_message_progress")
+    val hashHex = params.getString("message_hash")
+    val live = BridgeState.outboundMessages[hashHex]
+    val progress = live?.progress ?: -1.0
+    return JSONObject().put("progress", progress)
+}
+
 private fun cmdLxmfGetMessageState(params: JSONObject): JSONObject {
     ensureRouter("lxmf_get_message_state")
     val hashHex = params.getString("message_hash")
@@ -874,6 +910,7 @@ private val COMMANDS: Map<String, (JSONObject) -> JSONObject> = mapOf(
     "lxmf_sync_inbound" to ::cmdLxmfSyncInbound,
     "lxmf_get_received_messages" to ::cmdLxmfGetReceivedMessages,
     "lxmf_get_message_state" to ::cmdLxmfGetMessageState,
+    "lxmf_get_message_progress" to ::cmdLxmfGetMessageProgress,
     "lxmf_decode_bytes" to ::cmdLxmfDecodeBytes,
     "lxmf_shutdown" to ::cmdLxmfShutdown,
 )

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessage.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessage.kt
@@ -138,8 +138,26 @@ class LXMessage private constructor(
     /** Description of transport encryption used */
     var transportEncryption: String? = null
 
-    /** Progress of message delivery (0.0 to 1.0) */
-    var progress: Double = 0.0
+    /**
+     * Progress of message delivery (0.0 to 1.0).
+     *
+     * `@Volatile` because writers and readers run on different threads.
+     * Writers: `LXMRouter.processOpportunisticDelivery` (LXMRouter.kt:739,
+     * 755), `LXMRouter.sendViaPropagation`'s Resource progressCallback
+     * (LXMRouter.kt:1258), and `LXMRouter.sendViaLink`'s Resource
+     * progressCallback + completion callback (LXMRouter.kt:1335, 1340) —
+     * all dispatched from `processingScope` coroutines or RNS Resource
+     * background threads. Readers: any caller polling progress for UI
+     * display, plus the conformance bridge's `cmdLxmfGetMessageProgress`
+     * (Main.kt:740) reading from the bridge's JSON-RPC dispatch thread.
+     *
+     * Without `@Volatile`, the JLS allows non-volatile `double` reads to
+     * tear (§17.7) and offers no happens-before edge between the write
+     * and a cross-thread read — visibility of the latest value is
+     * implementation-defined. Python's GIL gives this for free; on JVM
+     * `@Volatile` is the direct equivalent.
+     */
+    @Volatile var progress: Double = 0.0
 
     // ===== Callbacks =====
 

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -39,4 +39,20 @@ This file is the **single source of truth** for every place where LXMF-kt's logi
 
 ## Deviations
 
-*(none yet — this file is new. As deviations are introduced or discovered, add them here.)*
+### `@Volatile` on `LXMessage.progress` — `lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessage.kt:142`
+
+**Python reference:** `LXMF/LXMF/LXMessage.py:156` (`self.progress = 0.0`), with cross-thread writers at `LXMessage.py:474, 488, 496, 506, 512, 559, 571, 583, 618` (the `__update_transfer_progress` callback path) and reads from any caller polling for UI progress display.
+
+**Category:** language/runtime forced
+
+**Date:** 2026-05-12
+
+**Tracking:** torlando-tech/LXMF-kt#34 (greptile review of `cmdLxmfGetMessageProgress`)
+
+**Description:** Python's GIL serialises attribute reads/writes — `self.progress = X` from a Resource progress callback thread is implicitly visible to a main-thread poller without any explicit synchronisation. On the JVM, `var progress: Double = 0.0` has neither visibility nor atomicity guarantees: JLS §17.7 explicitly permits non-volatile `double` (and `long`) reads to **tear** (be observed as 32-bit halves of two different writes), and there is no happens-before edge between a write on one thread and a read on another without a synchronisation action. HotSpot makes 64-bit reads atomic in practice on modern hardware, but ART (Android Runtime) does not guarantee this, and visibility (vs atomicity) is implementation-defined either way. `@Volatile` is the direct JVM idiom for "what Python's GIL gives you for free": each read sees the latest committed write, and 64-bit access is guaranteed atomic.
+
+Writers in this port: `LXMRouter.processOpportunisticDelivery` (LXMRouter.kt:739, 755) — `processingScope` coroutine; `LXMRouter.sendViaPropagation` Resource progressCallback (LXMRouter.kt:1258) — Resource background thread; `LXMRouter.sendViaLink` Resource progressCallback + completion callback (LXMRouter.kt:1335, 1340) — Resource background thread.
+
+Readers: any consumer polling progress for UI display, plus `:conformance-bridge`'s `cmdLxmfGetMessageProgress` (Main.kt:740), which is what surfaced this issue in code review.
+
+**Re-evaluation:** Remove `@Volatile` only if `LXMessage` ever migrates to an immutable / coroutine-`StateFlow`-backed progress representation, or if Kotlin gains a portable concurrency annotation that subsumes JVM-`@Volatile` semantics across all targets (Native, JS) the lib might one day support.


### PR DESCRIPTION
## Summary

The `conformance` CI check has been red on every LXMF-kt PR + push to main since 2026-05-09 with:

```
BridgeError: Unknown command: lxmf_get_message_progress
```

…in `tests/test_resource_progress.py`. That test was added to the [lxmf-conformance harness](https://github.com/torlando-tech/lxmf-conformance) on 2026-05-09 (commit `0cdc4e7`) to cover `LXMessage.progress` ticking during Resource transfer. It needs a new bridge command, `lxmf_get_message_progress`, on each LXMF impl's conformance bridge — python and microLXMF have it; LXMF-kt didn't. This PR adds it.

## Implementation

Mirrors `lxmf_python.py:cmd_lxmf_get_message_progress` closely. Reads the public `LXMessage.progress` field (`LXMessage.kt:142`), populated by `LXMRouter.sendViaLink`'s Resource `progressCallback` at `LXMRouter.kt:1340` and set to `1.0` on completion at `LXMRouter.kt:1335`. Returns the `-1.0` sentinel when `message_hash` isn't in `BridgeState.outboundMessages` (untracked).

### One intentional simplification vs python

Python pops messages from `_outbound_messages` on terminal state and keeps a snapshot in `_outbound_progress` so polling tests can still read `1.0` after `state == 'delivered'`. Kotlin never pops from `outboundMessages` until shutdown (`Main.kt:854` is the only `.clear()` site), so the live `LXMessage` reference itself persists past delivery and `message.progress = 1.0` survives the same poll window. No separate snapshot map needed. Documented in the function KDoc.

## Test plan

- [x] `INCLUDE_CONFORMANCE_BRIDGE=1 ./gradlew :conformance-bridge:shadowJar` — builds clean
- [x] `python3 -m pytest tests/test_resource_progress.py -v --impls python,kotlin` — **4/4 pass** (was 2/4; both `[kotlin->python]` and `[kotlin->kotlin]` previously failed)
- [x] `python3 -m pytest tests/ -v --impls python,kotlin` — **78 passed, 2 skipped, 6 xfailed**, no regressions. Skips/xfails are pre-existing (`lxmf_recall_app_data` not implemented, non-UTF-8 title/content round-trip tracked in #25)

## Why this PR exists ahead of the stamp-fix PRs

PRs #32 and #33 were going to land with the conformance check red because they branched off main while it was already failing. Project preference is no merges with red CI, so this clears the gate first. After this lands, those PRs should rebase to a green main and ship clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)