### PR TITLE
fix(LXMRouter): make path requests for propagation node sync requests

### DIFF
--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -58,6 +58,24 @@ class LXMRouter(
         /** Wait time for path discovery in milliseconds */
         const val PATH_REQUEST_WAIT = 7000L
 
+        /**
+         * Propagation-node path-request timeout, in milliseconds.
+         *
+         * Mirrors python `LXMRouter.PR_PATH_TIMEOUT = 10` (seconds) at
+         * `LXMF/LXMRouter.py:59`. Used by the path-wait job that runs after
+         * `requestMessagesFromPropagationNode()` issues an explicit
+         * `Transport.requestPath` because the active propagation node has
+         * no known path.
+         */
+        const val PR_PATH_TIMEOUT_MS = 10_000L
+
+        /**
+         * Poll interval for the propagation-node path-wait job, in
+         * milliseconds. Mirrors python `time.sleep(0.1)` in
+         * `__request_messages_path_job` at `LXMF/LXMRouter.py:1408`.
+         */
+        const val PR_PATH_POLL_INTERVAL_MS = 100L
+
         /** Maximum pathless delivery attempts before requesting path */
         const val MAX_PATHLESS_TRIES = 1
 
@@ -141,6 +159,23 @@ class LXMRouter(
     /** Link to active propagation node */
     @Volatile
     private var outboundPropagationLink: Link? = null
+
+    /**
+     * Destination hash the path-wait job (started by
+     * `requestMessagesFromPropagationNode` when no path is known) is waiting
+     * on. `null` when no wait is in progress. Mirrors python
+     * `wants_download_on_path_available_from` at `LXMF/LXMRouter.py:517`.
+     */
+    @Volatile
+    private var wantsDownloadOnPathAvailableFrom: ByteArray? = null
+
+    /**
+     * Wall-clock deadline (epoch ms) at which the path-wait job gives up.
+     * Mirrors python `wants_download_on_path_available_timeout` at
+     * `LXMF/LXMRouter.py:519`.
+     */
+    @Volatile
+    private var wantsDownloadOnPathAvailableTimeoutMs: Long = 0L
 
     /** Propagation transfer state */
     @Volatile
@@ -2153,7 +2188,23 @@ class LXMRouter(
             return
         }
 
-        propagationTransferState = PropagationTransferState.LINK_ESTABLISHING
+        // Defensive re-entry guard. A second caller (e.g. periodic sync timer
+        // overlapping a manual sync) arriving during PATH_REQUESTED would
+        // otherwise spawn a parallel `requestMessagesPathJob` — when the path
+        // resolves, both jobs would re-enter and race two concurrent
+        // `establishPropagationLink` calls. The legitimate retry from the
+        // path-wait job nulls `wantsDownloadOnPathAvailableFrom` before
+        // recursing, so the `!= null` clause lets that retry through.
+        // Python's reference (LXMRouter.py:484) carries the same race; we
+        // diverge intentionally because JVM coroutines hit it more readily
+        // than python threads under the GIL.
+        if (propagationTransferState == PropagationTransferState.PATH_REQUESTED &&
+            wantsDownloadOnPathAvailableFrom != null
+        ) {
+            println("[LXMRouter] requestMessages: path-wait already in progress, ignoring duplicate call")
+            return
+        }
+
         propagationTransferProgress = 0.0
         propagationTransferLastResult = 0
 
@@ -2170,11 +2221,73 @@ class LXMRouter(
             // ERROR_NO_IDENTITY (240) on /get requests.
             identifyOnLink(link)
             requestMessageList(link)
+        } else if (link == null) {
+            // Mirror python `request_messages_from_propagation_node` at
+            // LXMF/LXMRouter.py:503-521: only attempt to establish a link
+            // when Transport already knows a path. Otherwise, request the
+            // path and let the path-wait job re-enter this function once
+            // the path arrives. Without this preflight, Link.create issues
+            // a hopeful broadcast with no route and the propagation
+            // transfer stalls in LINK_ESTABLISHING until the caller's
+            // outer timeout fires.
+            if (Transport.hasPath(node.destHash)) {
+                propagationTransferState = PropagationTransferState.LINK_ESTABLISHING
+                establishPropagationLink(node)
+            } else {
+                println("[LXMRouter] No path known for propagation node ${node.hexHash.take(12)}, requesting path...")
+                Transport.requestPath(node.destHash)
+                wantsDownloadOnPathAvailableFrom = node.destHash
+                wantsDownloadOnPathAvailableTimeoutMs =
+                    System.currentTimeMillis() + PR_PATH_TIMEOUT_MS
+                propagationTransferState = PropagationTransferState.PATH_REQUESTED
+                requestMessagesPathJob()
+            }
         } else {
-            // Need to establish link first
-            establishPropagationLink(node)
+            // Link exists but not yet ACTIVE — establishedCallback will
+            // continue the flow when it fires. Mirrors python
+            // `Waiting for propagation node link to become active` at
+            // LXMRouter.py:523.
+            println("[LXMRouter] Waiting for propagation node link to become active")
         }
         println("[LXMRouter] requestMessages: returning, state=$propagationTransferState")
+    }
+
+    /**
+     * Background poll that waits for `Transport.hasPath` to become true for
+     * `wantsDownloadOnPathAvailableFrom`, then re-enters
+     * `requestMessagesFromPropagationNode` so the link can be established.
+     * On timeout, sets state to `NO_PATH`.
+     *
+     * Mirrors python `__request_messages_path_job` at
+     * `LXMF/LXMRouter.py:1405-1414`. Python uses a daemon thread; we use a
+     * coroutine on `processingScope` (Dispatchers.IO) which serves the same
+     * purpose without blocking caller threads.
+     */
+    private fun requestMessagesPathJob() {
+        processingScope.launch {
+            val deadline = wantsDownloadOnPathAvailableTimeoutMs
+            // Re-read `wantsDownloadOnPathAvailableFrom` on each iteration so
+            // a concurrent reset/cancel that nulls the field cleanly aborts
+            // the wait. Mirrors python LXMRouter.py:1407 which re-reads
+            // `self.wants_download_on_path_available_from` inside its loop
+            // and in the post-loop `has_path` check at LXMRouter.py:1410.
+            while (true) {
+                val current = wantsDownloadOnPathAvailableFrom ?: return@launch
+                if (Transport.hasPath(current)) break
+                if (System.currentTimeMillis() >= deadline) break
+                delay(PR_PATH_POLL_INTERVAL_MS)
+            }
+            val target = wantsDownloadOnPathAvailableFrom ?: return@launch
+            if (Transport.hasPath(target)) {
+                println("[LXMRouter] Path to propagation node resolved, retrying message request")
+                wantsDownloadOnPathAvailableFrom = null
+                requestMessagesFromPropagationNode()
+            } else {
+                println("[LXMRouter] Propagation node path request timed out")
+                wantsDownloadOnPathAvailableFrom = null
+                propagationTransferState = PropagationTransferState.NO_PATH
+            }
+        }
     }
 
     /**

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/PropagationSyncTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/PropagationSyncTest.kt
@@ -73,11 +73,100 @@ class PropagationSyncTest {
         val state = router.propagationTransferState
         println("State after sync: $state")
 
-        // Should NOT be FAILED (should be LINK_ESTABLISHING)
+        // Should NOT be FAILED. With the path-request preflight in place, the
+        // transient state here is PATH_REQUESTED (no real interfaces in the
+        // test, so Transport has no path); previously it was LINK_ESTABLISHING.
         assertNotEquals(
             LXMRouter.PropagationTransferState.FAILED,
             state,
             "Sync should not fail when node is in map and hash is set",
+        )
+
+        router.close()
+    }
+
+    @Test
+    fun `requestMessages enters PATH_REQUESTED when no path is known`() {
+        // Mirror python LXMF/LXMRouter.py:514-520: when Transport has no path
+        // to the active propagation node, the request must transition into
+        // PR_PATH_REQUESTED so the path-wait job can resolve before linking.
+        val router = LXMRouter(identity = identity)
+        val nodeIdentity = Identity.create()
+        val nodeDestHash =
+            network.reticulum.destination.Destination.hash(
+                nodeIdentity,
+                "lxmf",
+                "propagation",
+            )
+        val nodeHexHash = nodeDestHash.joinToString("") { "%02x".format(it) }
+
+        router.setActivePropagationNode(nodeHexHash)
+        router.addPropagationNode(
+            LXMRouter.PropagationNode(
+                destHash = nodeDestHash,
+                identity = nodeIdentity,
+                isActive = true,
+            ),
+        )
+        router.start()
+
+        // Test precondition: with enableTransport=false there are no interfaces,
+        // so Transport cannot have a path to a freshly-generated identity.
+        check(!Transport.hasPath(nodeDestHash)) { "Transport unexpectedly knew a path" }
+
+        router.requestMessagesFromPropagationNode()
+
+        assertEquals(
+            LXMRouter.PropagationTransferState.PATH_REQUESTED,
+            router.propagationTransferState,
+            "Should enter PATH_REQUESTED when no path is known",
+        )
+
+        router.close()
+    }
+
+    @Test
+    fun `duplicate requestMessages during PATH_REQUESTED is a no-op`() {
+        // Concurrent callers (manual sync racing the periodic timer, etc.)
+        // must not spawn a second path-wait job. The first call sets state
+        // to PATH_REQUESTED; the second call must early-return so we don't
+        // race two `requestMessagesPathJob` coroutines that both retry when
+        // the path arrives.
+        val router = LXMRouter(identity = identity)
+        val nodeIdentity = Identity.create()
+        val nodeDestHash =
+            network.reticulum.destination.Destination.hash(
+                nodeIdentity,
+                "lxmf",
+                "propagation",
+            )
+        val nodeHexHash = nodeDestHash.joinToString("") { "%02x".format(it) }
+
+        router.setActivePropagationNode(nodeHexHash)
+        router.addPropagationNode(
+            LXMRouter.PropagationNode(
+                destHash = nodeDestHash,
+                identity = nodeIdentity,
+                isActive = true,
+            ),
+        )
+        router.start()
+        check(!Transport.hasPath(nodeDestHash)) { "Transport unexpectedly knew a path" }
+
+        router.requestMessagesFromPropagationNode()
+        assertEquals(
+            LXMRouter.PropagationTransferState.PATH_REQUESTED,
+            router.propagationTransferState,
+            "First call should enter PATH_REQUESTED",
+        )
+
+        // Second call while the wait is in progress — must not advance state
+        // or change the path-wait deadline.
+        router.requestMessagesFromPropagationNode()
+        assertEquals(
+            LXMRouter.PropagationTransferState.PATH_REQUESTED,
+            router.propagationTransferState,
+            "Duplicate call must not transition out of PATH_REQUESTED",
         )
 
         router.close()


### PR DESCRIPTION
This is a fix for https://github.com/torlando-tech/columba/issues/752. Sync requests now work reliably and quickly. Unless I'm missing something, it doesn't look like we were making path requests in the propagation sync path at all before.