### PR TITLE
Add LXMF interaction field + dict-index constants (reply/reaction/comment/continuation)

### DIFF
--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMFConstants.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMFConstants.kt
@@ -58,6 +58,29 @@ object LXMFConstants {
     /** Rendering hints */
     const val FIELD_RENDERER = 0x0F
 
+    // Interaction fields (reply / reaction / comment / continuation),
+    // standardised upstream in LXMF.py (commit 764758d, "to be finalized
+    // in 1.0.0"). See the dict-index sub-constants further below.
+
+    /** Reply target — Bytes, full LXMessage.hash. */
+    const val FIELD_REPLY_TO = 0x30
+
+    /** Reply quote — Bytes, quoted content in UTF-8 encoding. */
+    const val FIELD_REPLY_QUOTE = 0x31
+
+    /** Reaction — Dict, keyed by the REACTION_* dict indices below. */
+    const val FIELD_REACTION = 0x40
+
+    /** Comment — Dict, keyed by the COMMENT_* dict indices below. */
+    const val FIELD_COMMENT = 0x41
+
+    /** Continuation — Dict, keyed by the CONTINUATION_* dict indices below. */
+    const val FIELD_CONTINUATION = 0x42
+
+    // Unallocated fields between 0x00 and 0x80, both included, should be
+    // considered reserved for future extensibility. For experimental and
+    // unstable features, it is recommended to use fields above 0xFF.
+
     // Custom fields (0xFB-0xFF) for extensibility
 
     /** Custom format/type/protocol identifier */
@@ -116,6 +139,22 @@ object LXMFConstants {
 
     /** BBCode rendering */
     const val RENDERER_BBCODE = 0x03
+
+    // ===== Interaction dict indices =====
+    // Dict indices are integers to preserve bandwidth. Mirrors the
+    // "Reaction / Comment / Continuation dict indices" block in LXMF.py.
+
+    /** FIELD_REACTION key — Bytes, full LXMessage.hash being reacted to. */
+    const val REACTION_TO = 0x00
+
+    /** FIELD_REACTION key — Bytes, the reaction content in UTF-8 encoding. */
+    const val REACTION_CONTENT = 0x01
+
+    /** FIELD_COMMENT key — Bytes, full LXMessage.hash being commented on. */
+    const val COMMENT_FOR = 0x00
+
+    /** FIELD_CONTINUATION key — Bytes, full LXMessage.hash being continued. */
+    const val CONTINUATION_OF = 0x00
 
     // ===== Propagation Node Metadata Fields =====
 

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/AttachmentFieldInteropTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/AttachmentFieldInteropTest.kt
@@ -114,20 +114,6 @@ class AttachmentFieldInteropTest : LXMFInteropTestBase() {
         }
     }
 
-    /**
-     * Verify message in Python using the new lxmf_unpack_with_fields command.
-     */
-    private fun verifyInPythonWithFields(lxmfBytes: ByteArray): JsonObject {
-        val startTime = System.currentTimeMillis()
-
-        val result = python("lxmf_unpack_with_fields", "lxmf_bytes" to lxmfBytes.toHex())
-
-        val elapsed = System.currentTimeMillis() - startTime
-        println("  [Python] lxmf_unpack_with_fields completed in ${elapsed}ms")
-
-        return result
-    }
-
     @Test
     fun `single text attachment round-trips correctly`() {
         println("\n=== Test: single text attachment round-trips correctly ===")

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/CustomFieldInteropTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/CustomFieldInteropTest.kt
@@ -27,20 +27,6 @@ import kotlin.random.Random
 class CustomFieldInteropTest : LXMFInteropTestBase() {
 
     /**
-     * Verify message in Python using the lxmf_unpack_with_fields command.
-     */
-    private fun verifyInPythonWithFields(lxmfBytes: ByteArray): JsonObject {
-        val startTime = System.currentTimeMillis()
-
-        val result = python("lxmf_unpack_with_fields", "lxmf_bytes" to lxmfBytes.toHex())
-
-        val elapsed = System.currentTimeMillis() - startTime
-        println("  [Python] lxmf_unpack_with_fields completed in ${elapsed}ms")
-
-        return result
-    }
-
-    /**
      * Parse an integer field value from the fields_hex structure.
      * Handles msgpack Long vs Int deserialization.
      */

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ImageFieldInteropTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ImageFieldInteropTest.kt
@@ -151,20 +151,6 @@ class ImageFieldInteropTest : LXMFInteropTestBase() {
         return ParsedImageField(extension, content)
     }
 
-    /**
-     * Verify message in Python using lxmf_unpack_with_fields command.
-     */
-    private fun verifyInPythonWithFields(lxmfBytes: ByteArray): kotlinx.serialization.json.JsonObject {
-        val startTime = System.currentTimeMillis()
-
-        val result = python("lxmf_unpack_with_fields", "lxmf_bytes" to lxmfBytes.toHex())
-
-        val elapsed = System.currentTimeMillis() - startTime
-        println("  [Python] lxmf_unpack_with_fields completed in ${elapsed}ms")
-
-        return result
-    }
-
     @Test
     fun `webp image field round-trips correctly`() {
         println("\n=== Test: webp image field round-trips correctly ===")

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/LXMFInteropTestBase.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/LXMFInteropTestBase.kt
@@ -3,6 +3,7 @@ package network.reticulum.lxmf.interop
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import network.reticulum.common.DestinationDirection
 import network.reticulum.common.DestinationType
 import network.reticulum.common.toHexString
@@ -158,5 +159,37 @@ abstract class LXMFInteropTestBase : InteropTestBase() {
             kotlinMessage.hash?.toHex() shouldBe pythonResult.getString("message_hash")
                 .also { println("  ${prefix}message_hash: ${kotlinMessage.hash?.toHex()}") }
         }
+    }
+
+    /**
+     * Verify an LXMF message in Python via the bridge, returning the full
+     * field map. Sends the packed bytes to Python's `lxmf_unpack_with_fields`
+     * command (vs [verifyInPython], which uses `lxmf_unpack` without fields).
+     *
+     * Shared by every interop suite that asserts on `fields_hex` so the
+     * bridge command + result schema live in exactly one place.
+     *
+     * @param lxmfBytes Packed LXMF message bytes
+     * @return JsonObject with unpacked message including the `fields_hex` map
+     */
+    protected fun verifyInPythonWithFields(lxmfBytes: ByteArray): JsonObject {
+        val startTime = System.currentTimeMillis()
+
+        val result = python("lxmf_unpack_with_fields", "lxmf_bytes" to lxmfBytes.toHex())
+
+        val elapsed = System.currentTimeMillis() - startTime
+        println("  [Python] lxmf_unpack_with_fields completed in ${elapsed}ms")
+
+        return result
+    }
+
+    /**
+     * Read the bridge-reported `type` of a single field from a
+     * [verifyInPythonWithFields] result, or null if the field is absent.
+     */
+    protected fun parseFieldType(pythonResult: JsonObject, fieldKey: Int): String? {
+        val fieldsHex = pythonResult["fields_hex"]?.jsonObject ?: return null
+        val fieldObj = fieldsHex[fieldKey.toString()]?.jsonObject ?: return null
+        return fieldObj.getString("type")
     }
 }

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/MessageHashInteropTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/MessageHashInteropTest.kt
@@ -3,7 +3,6 @@ package network.reticulum.lxmf.interop
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import kotlinx.serialization.json.JsonObject
 import network.reticulum.interop.getString
 import network.reticulum.interop.toHex
 import network.reticulum.lxmf.LXMFConstants
@@ -21,21 +20,6 @@ import org.junit.jupiter.api.Test
  * is computed over hashedPart + hash.
  */
 class MessageHashInteropTest : LXMFInteropTestBase() {
-
-    /**
-     * Verify message in Python using lxmf_unpack_with_fields command.
-     * This handles binary field values properly for JSON serialization.
-     */
-    private fun verifyInPythonWithFields(lxmfBytes: ByteArray): JsonObject {
-        val startTime = System.currentTimeMillis()
-
-        val result = python("lxmf_unpack_with_fields", "lxmf_bytes" to lxmfBytes.toHex())
-
-        val elapsed = System.currentTimeMillis() - startTime
-        println("  [Python] lxmf_unpack_with_fields completed in ${elapsed}ms")
-
-        return result
-    }
 
     @Nested
     @DisplayName("BasicHashComputation")

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ReactionFieldInteropTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ReactionFieldInteropTest.kt
@@ -62,14 +62,18 @@ class ReactionFieldInteropTest : LXMFInteropTestBase() {
         println("  [Kotlin] Packed ${packed.size} bytes with FIELD_REACTION (0x40)")
 
         val pythonResult = verifyInPythonWithFields(packed)
-        val fieldsHex = pythonResult["fields_hex"]?.jsonObject
+        // Hard precondition: without fields_hex nothing below is meaningful, and a
+        // null deref inside assertSoftly would throw a RuntimeException that escapes
+        // the soft block and hides the other collected failures.
+        val fieldsHex = requireNotNull(pythonResult["fields_hex"]?.jsonObject) {
+            "Python returned no fields_hex for the packed reaction message"
+        }
         val reactionType = parseFieldType(pythonResult, LXMFConstants.FIELD_REACTION)
         println("  [Python] FIELD_REACTION type: $reactionType")
 
         assertSoftly {
             // Python LXMF unpacked the message and surfaced field 0x40 ("64").
-            fieldsHex shouldNotBe null
-            fieldsHex!!.containsKey(LXMFConstants.FIELD_REACTION.toString()) shouldBe true
+            fieldsHex.containsKey(LXMFConstants.FIELD_REACTION.toString()) shouldBe true
             // The nested int-keyed bytes dict survives as a structured type
             // (not collapsed to bytes / dropped).
             reactionType shouldNotBe null

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ReactionFieldInteropTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ReactionFieldInteropTest.kt
@@ -3,10 +3,7 @@ package network.reticulum.lxmf.interop
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
-import network.reticulum.interop.getString
-import network.reticulum.interop.toHex
 import network.reticulum.lxmf.LXMFConstants
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
@@ -30,15 +27,6 @@ import kotlin.random.Random
  * bridge's nested representation.
  */
 class ReactionFieldInteropTest : LXMFInteropTestBase() {
-
-    private fun verifyInPythonWithFields(lxmfBytes: ByteArray): JsonObject =
-        python("lxmf_unpack_with_fields", "lxmf_bytes" to lxmfBytes.toHex())
-
-    private fun parseFieldType(pythonResult: JsonObject, fieldKey: Int): String? {
-        val fieldsHex = pythonResult["fields_hex"]?.jsonObject ?: return null
-        val fieldObj = fieldsHex[fieldKey.toString()]?.jsonObject ?: return null
-        return fieldObj.getString("type")
-    }
 
     @Test
     fun `FIELD_REACTION canonical 0x40 nested dict round-trips to Python`() {

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ReactionFieldInteropTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/ReactionFieldInteropTest.kt
@@ -1,0 +1,81 @@
+package network.reticulum.lxmf.interop
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import network.reticulum.interop.getString
+import network.reticulum.interop.toHex
+import network.reticulum.lxmf.LXMFConstants
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+/**
+ * Tests the canonical LXMF reaction field (FIELD_REACTION 0x40) round-trips
+ * Kotlin→Python.
+ *
+ * The reaction value is a nested dict with integer keys and byte-array values
+ * (standardised in LXMF.py commit 764758d):
+ * ```
+ * fields[0x40] = { 0x00: <target LXMessage.hash bytes>,    # REACTION_TO
+ *                  0x01: <reaction content UTF-8 bytes> }  # REACTION_CONTENT
+ * ```
+ * This is the shape Columba's kotlin-native backend puts on the wire (it packs
+ * via [LXMessage.pack]); the assertion that matters is that Python LXMF
+ * unpacks the int-keyed nested-bytes dict without error and surfaces field
+ * 0x40. Value-level rendering of the nested dict is bridge-dependent, so —
+ * like [TelemetryFieldInteropTest]'s map test — this asserts the field
+ * survives and is a structured (map/dict) type rather than over-asserting the
+ * bridge's nested representation.
+ */
+class ReactionFieldInteropTest : LXMFInteropTestBase() {
+
+    private fun verifyInPythonWithFields(lxmfBytes: ByteArray): JsonObject =
+        python("lxmf_unpack_with_fields", "lxmf_bytes" to lxmfBytes.toHex())
+
+    private fun parseFieldType(pythonResult: JsonObject, fieldKey: Int): String? {
+        val fieldsHex = pythonResult["fields_hex"]?.jsonObject ?: return null
+        val fieldObj = fieldsHex[fieldKey.toString()]?.jsonObject ?: return null
+        return fieldObj.getString("type")
+    }
+
+    @Test
+    fun `FIELD_REACTION canonical 0x40 nested dict round-trips to Python`() {
+        println("\n=== Test: FIELD_REACTION (0x40) canonical nested dict ===")
+
+        // 32-byte target message hash + a multi-codepoint emoji as UTF-8 bytes.
+        val targetHash = Random.nextBytes(32)
+        val emojiBytes = "👍🏽".toByteArray(Charsets.UTF_8)
+
+        val message = createTestMessage(
+            content = "", // reaction is an otherwise-empty side-channel message
+            fields = mutableMapOf(
+                LXMFConstants.FIELD_REACTION to mapOf(
+                    LXMFConstants.REACTION_TO to targetHash,
+                    LXMFConstants.REACTION_CONTENT to emojiBytes,
+                ),
+            ),
+        )
+
+        val packed = message.pack()
+        println("  [Kotlin] Packed ${packed.size} bytes with FIELD_REACTION (0x40)")
+
+        val pythonResult = verifyInPythonWithFields(packed)
+        val fieldsHex = pythonResult["fields_hex"]?.jsonObject
+        val reactionType = parseFieldType(pythonResult, LXMFConstants.FIELD_REACTION)
+        println("  [Python] FIELD_REACTION type: $reactionType")
+
+        assertSoftly {
+            // Python LXMF unpacked the message and surfaced field 0x40 ("64").
+            fieldsHex shouldNotBe null
+            fieldsHex!!.containsKey(LXMFConstants.FIELD_REACTION.toString()) shouldBe true
+            // The nested int-keyed bytes dict survives as a structured type
+            // (not collapsed to bytes / dropped).
+            reactionType shouldNotBe null
+            reactionType shouldNotBe "bytes"
+        }
+
+        println("  SUCCESS: FIELD_REACTION 0x40 nested dict round-trips (type=$reactionType)")
+    }
+}

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/TelemetryFieldInteropTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/interop/TelemetryFieldInteropTest.kt
@@ -24,16 +24,6 @@ import kotlin.random.Random
  */
 class TelemetryFieldInteropTest : LXMFInteropTestBase() {
 
-    private fun verifyInPythonWithFields(lxmfBytes: ByteArray): JsonObject {
-        return python("lxmf_unpack_with_fields", "lxmf_bytes" to lxmfBytes.toHex())
-    }
-
-    private fun parseFieldType(pythonResult: JsonObject, fieldKey: Int): String? {
-        val fieldsHex = pythonResult["fields_hex"]?.jsonObject ?: return null
-        val fieldObj = fieldsHex[fieldKey.toString()]?.jsonObject ?: return null
-        return fieldObj.getString("type")
-    }
-
     private fun parseBytesField(pythonResult: JsonObject, fieldKey: Int): ByteArray? {
         val fieldsHex = pythonResult["fields_hex"]?.jsonObject ?: return null
         val fieldObj = fieldsHex[fieldKey.toString()]?.jsonObject ?: return null


### PR DESCRIPTION
Mirrors the reply/reaction/comment/continuation field standard added upstream in `LXMF.py` (commit `764758d`, "to be finalized in 1.0.0"):

| Constant | Value |
|---|---|
| `FIELD_REPLY_TO` | `0x30` |
| `FIELD_REPLY_QUOTE` | `0x31` |
| `FIELD_REACTION` | `0x40` |
| `FIELD_COMMENT` | `0x41` |
| `FIELD_CONTINUATION` | `0x42` |

Plus the integer dict indices `REACTION_TO`/`REACTION_CONTENT` (`0x00`/`0x01`), `COMMENT_FOR` (`0x00`), `CONTINUATION_OF` (`0x00`), and the note that fields `0x00`–`0x80` are reserved for future extensibility.

### Tests
Adds `ReactionFieldInteropTest` — packs the canonical nested int-keyed bytes dict `fields[0x40] = {0x00: hashBytes, 0x01: emojiBytes}` and verifies Python LXMF unpacks it and surfaces `0x40` as a structured field. Mirrors `TelemetryFieldInteropTest`'s nested-map precedent (asserts survival + structure; nested value rendering is bridge-dependent). Part of the conformance suite (CI; excluded from the default local `test` task).

### Notes
- Faithful mirror of `LXMF.py` — no behavioural change, no port deviation.
- Consumed by the Columba reaction-wire migration to the canonical `0x40` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)