### PR TITLE
fix(router): DIRECT delivery requests a path before linking (columba#1004)

### DIFF
--- a/lxmf-core/build.gradle.kts
+++ b/lxmf-core/build.gradle.kts
@@ -20,19 +20,13 @@ dependencies {
     // api scope: lxmf-core's public API (LXMRouter, LXMessage) exposes
     // rns-core types (Destination, Identity) as parameters and return types,
     // so consumers need rns-core on their compile classpath.
-    //
-    // TODO(columba#1004): `0.0.22-1004dev` is a LOCAL dev placeholder published
-    // via `publishToMavenLocal` from the reticulum-kt PR-1 branch
-    // (fix/request-path-python-parity). Replace all three reticulum-kt pins
-    // below with PR 1's real tag once it is merged + tagged. Until then, build
-    // with `LOCAL_RETICULUM_KT_VIA_MAVEN_LOCAL=1`.
-    api("com.github.torlando-tech.reticulum-kt:rns-core:0.0.22-1004dev")
+    api("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.22")
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
     // Test dependencies for live networking tests
-    testImplementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:0.0.22-1004dev")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:v0.0.22")
 
     // MessagePack for serialization (already in rns-core, but explicit)
     implementation("org.msgpack:msgpack-core:0.9.8")
@@ -49,7 +43,7 @@ dependencies {
     testRuntimeOnly("org.slf4j:slf4j-simple:2.0.9")
 
     // Interop testing - reuse Python bridge infrastructure from rns-test
-    testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:0.0.22-1004dev")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:v0.0.22")
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
     // Compression - Apache Commons Compress for BZ2 interop tests

--- a/lxmf-core/build.gradle.kts
+++ b/lxmf-core/build.gradle.kts
@@ -20,13 +20,19 @@ dependencies {
     // api scope: lxmf-core's public API (LXMRouter, LXMessage) exposes
     // rns-core types (Destination, Identity) as parameters and return types,
     // so consumers need rns-core on their compile classpath.
-    api("com.github.torlando-tech.reticulum-kt:rns-core:v0.0.17")
+    //
+    // TODO(columba#1004): `0.0.22-1004dev` is a LOCAL dev placeholder published
+    // via `publishToMavenLocal` from the reticulum-kt PR-1 branch
+    // (fix/request-path-python-parity). Replace all three reticulum-kt pins
+    // below with PR 1's real tag once it is merged + tagged. Until then, build
+    // with `LOCAL_RETICULUM_KT_VIA_MAVEN_LOCAL=1`.
+    api("com.github.torlando-tech.reticulum-kt:rns-core:0.0.22-1004dev")
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
     // Test dependencies for live networking tests
-    testImplementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:v0.0.17")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-interfaces:0.0.22-1004dev")
 
     // MessagePack for serialization (already in rns-core, but explicit)
     implementation("org.msgpack:msgpack-core:0.9.8")
@@ -43,7 +49,7 @@ dependencies {
     testRuntimeOnly("org.slf4j:slf4j-simple:2.0.9")
 
     // Interop testing - reuse Python bridge infrastructure from rns-test
-    testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:v0.0.17")
+    testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:0.0.22-1004dev")
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
     // Compression - Apache Commons Compress for BZ2 interop tests

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -674,6 +674,10 @@ class LXMRouter(
     @org.jetbrains.annotations.VisibleForTesting
     internal var testHookOnProcessOutboundMessage: (suspend (LXMessage) -> Unit)? = null
 
+    /** Test seam: the current DIRECT delivery link for a destination, if any. */
+    @org.jetbrains.annotations.VisibleForTesting
+    internal fun directLinkForTest(destHashHex: String): Link? = directLinks[destHashHex]
+
     /**
      * Process a single outbound message based on its delivery method.
      */
@@ -916,29 +920,51 @@ class LXMRouter(
             }
 
             link != null && link.status == LinkConstants.CLOSED -> {
-                // Link is closed (likely establishment timeout). Clear it and
-                // schedule a retry; the next tick will hit the no-link branch
-                // and bump deliveryAttempts. (Python LXMRouter.py:2625-2629.)
+                // Safety net only. In kt the per-link [closedCallback] in
+                // [establishLinkForMessage] fires on close and eagerly removes the
+                // link from directLinks (+ re-requests the path — see there), so a
+                // CLOSED link is almost never observed here; the next tick lands in
+                // the no-link branch. Python's per-message CLOSED branch
+                // (LXMRouter.py:2610-2629) is relocated to that callback because
+                // kt's link lifecycle is event-driven (see port-deviations.md).
+                // If we do see a CLOSED link (close-callback race), just clear both
+                // link maps and reschedule.
                 directLinks.remove(destHashHex)
+                backchannelLinks.remove(destHashHex)
                 pendingLinkEstablishments.remove(destHashHex)
                 message.nextDeliveryAttempt = System.currentTimeMillis() + DELIVERY_RETRY_WAIT
             }
 
             else -> {
-                // No link exists. Bump attempts and try to create one — but
-                // only after the retry-wait window has elapsed, so we don't
-                // burn the budget on rapid-fire ticks. (Python LXMRouter.py:2637-2639.)
+                // No link exists. Try to establish one, but only if we've never
+                // tried before or the retry-wait window has elapsed. Port of
+                // Python LXMRouter.py:2633-2652.
                 val now = System.currentTimeMillis()
                 val nextAttempt = message.nextDeliveryAttempt ?: 0L
                 if (nextAttempt == 0L || now >= nextAttempt) {
                     message.deliveryAttempts++
-                    if (message.deliveryAttempts > MAX_DELIVERY_ATTEMPTS) {
-                        message.state = MessageState.FAILED
-                        message.failedCallback?.invoke(message)
-                        return
-                    }
                     message.nextDeliveryAttempt = now + DELIVERY_RETRY_WAIT
-                    establishLinkForMessage(message)
+
+                    // Strictly `<` MAX (Python :2641): on the attempt that reaches
+                    // MAX we neither establish nor request — the next tick's
+                    // top-of-function check (deliveryAttempts > MAX) fails the
+                    // message and invokes failedCallback, matching Python's
+                    // `<= MAX` gate at :2579 + fail_message at :2655.
+                    if (message.deliveryAttempts < MAX_DELIVERY_ATTEMPTS) {
+                        if (Transport.hasPath(message.destinationHash)) {
+                            // Path known — establish the link. (:2642-2647)
+                            establishLinkForMessage(message)
+                            message.progress = 0.03
+                        } else {
+                            // No path — request one and wait PATH_REQUEST_WAIT before
+                            // the next attempt. This is the core columba#1004 fix:
+                            // DIRECT delivery now requests a path instead of blindly
+                            // attempting a link against a missing/stale path. (:2648-2652)
+                            Transport.requestPath(message.destinationHash)
+                            message.nextDeliveryAttempt = now + PATH_REQUEST_WAIT
+                            message.progress = 0.01
+                        }
+                    }
                 }
             }
         }
@@ -986,6 +1012,33 @@ class LXMRouter(
                         triggerProcessing()
                     },
                     closedCallback = { closedLink ->
+                        // Re-request the path when a DIRECT delivery link closes.
+                        // Port of Python's CLOSED-branch logic (LXMRouter.py:2610-2622):
+                        // Python runs this per-message in process_outbound, but kt's
+                        // link lifecycle is event-driven and removes the link from
+                        // directLinks here (so processDirectDelivery's CLOSED branch is
+                        // pre-empted), so the re-request is replicated at the close
+                        // event. See port-deviations.md. Without this, transport-enabled
+                        // nodes — where reticulum-kt's Transport.deregisterLink path
+                        // recovery is intentionally gated off (Python parity) — had no
+                        // way to refresh a stale path after a failed link (columba#1004).
+                        //
+                        // Gate on the message still needing delivery so a normal
+                        // post-delivery close doesn't emit a spurious request (Python's
+                        // CLOSED branch only runs for messages still in the outbound loop).
+                        val stillDelivering = message.state == MessageState.OUTBOUND ||
+                            message.state == MessageState.SENDING
+                        if (stillDelivering) {
+                            if (closedLink.activatedAt > 0) {
+                                // Was active, closed unexpectedly — refresh the path. (:2611-2613)
+                                Transport.requestPath(message.destinationHash)
+                            } else if (!message.pathRequestRetried) {
+                                // Never activated — retry the path request exactly once. (:2615-2618)
+                                Transport.requestPath(message.destinationHash)
+                                message.pathRequestRetried = true
+                            }
+                        }
+
                         // Link closed
                         directLinks.remove(destHashHex)
                         pendingLinkEstablishments.remove(destHashHex)

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt
@@ -877,11 +877,6 @@ class LXMRouter(
 
         val destHashHex = message.destinationHash.toHexString()
 
-        // Debug logging
-        println("[LXMRouter] processDirectDelivery: destHashHex=$destHashHex")
-        println("[LXMRouter] processDirectDelivery: directLinks keys=${directLinks.keys}")
-        println("[LXMRouter] processDirectDelivery: backchannelLinks keys=${backchannelLinks.keys}")
-
         // Check for existing active link — prefer directLinks (WE initiated),
         // fall back to backchannelLinks (THEY initiated). Python LXMF sets up
         // resource receive callbacks on ALL links via delivery_link_established,
@@ -894,17 +889,6 @@ class LXMRouter(
                 link = backchannel
             }
         }
-        println(
-            "[LXMRouter] processDirectDelivery: found link=${link != null}, status=${link?.status}, source=${if (link != null &&
-                backchannelLinks.containsValue(
-                    link,
-                )
-            ) {
-                "backchannel"
-            } else {
-                "direct"
-            }}",
-        )
 
         when {
             link != null && link.status == LinkConstants.ACTIVE -> {

--- a/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessage.kt
+++ b/lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMessage.kt
@@ -175,6 +175,15 @@ class LXMessage private constructor(
     /** Next delivery attempt timestamp (milliseconds) */
     var nextDeliveryAttempt: Long? = null
 
+    /**
+     * Whether a path re-request has already been issued for a CLOSED delivery
+     * link that never activated. Transient delivery-state — NOT part of the
+     * packed wire format. Mirrors Python LXMF's dynamic `path_request_retried`
+     * attribute (LXMRouter.py:2615-2618), which gates the never-activated retry
+     * to exactly once.
+     */
+    var pathRequestRetried: Boolean = false
+
     // ===== Receive-time Packet Metadata =====
     //
     // The following fields are populated from the delivering Reticulum packet

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/DirectDeliveryPathRequestTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/DirectDeliveryPathRequestTest.kt
@@ -1,0 +1,295 @@
+package network.reticulum.lxmf
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import network.reticulum.common.DestinationDirection
+import network.reticulum.common.DestinationType
+import network.reticulum.common.InterfaceMode
+import network.reticulum.common.PacketType
+import network.reticulum.common.RnsConstants
+import network.reticulum.common.toKey
+import network.reticulum.destination.Destination
+import network.reticulum.identity.Identity
+import network.reticulum.link.LinkConstants
+import network.reticulum.packet.Packet
+import network.reticulum.transport.InterfaceRef
+import network.reticulum.transport.PathEntry
+import network.reticulum.transport.PathState
+import network.reticulum.transport.Transport
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for columba#1004 (PR 2 — LXMF-kt DIRECT delivery path
+ * requests).
+ *
+ * Pre-fix, [LXMRouter.processDirectDelivery]'s no-link branch called
+ * `establishLinkForMessage` with **no `Transport.hasPath` check and no
+ * `Transport.requestPath`**, so a DIRECT message to a destination that hadn't
+ * announced since the app opened (no usable path) would blindly attempt a link
+ * that could never establish, then fall back to PROPAGATED — never emitting the
+ * path request needed to actually reach the destination. Python LXMF requests a
+ * path first (LXMRouter.py:2648-2652).
+ *
+ * Separately, a DIRECT link that closes (establishment timeout / unexpected
+ * close) must re-request the path (Python LXMRouter.py:2610-2622). kt's link
+ * lifecycle is event-driven, so that re-request lives in the link
+ * `closedCallback` (see port-deviations.md), gated on the message still
+ * needing delivery.
+ *
+ * Drives the real [Transport] singleton with an inline [CapturingInterface]
+ * (same pattern as reticulum-kt's TransportOutboundHeaderTypeTest).
+ */
+@DisplayName("LXMF DIRECT delivery path requests (columba#1004)")
+class DirectDeliveryPathRequestTest {
+
+    private class CapturingInterface(
+        override val name: String,
+    ) : InterfaceRef {
+        val sent = mutableListOf<ByteArray>()
+
+        override val hash: ByteArray = ByteArray(RnsConstants.TRUNCATED_HASH_BYTES) { 0xAA.toByte() }
+        override val canSend: Boolean = true
+        override val canReceive: Boolean = true
+        override val online: Boolean = true
+        override val mode: InterfaceMode = InterfaceMode.FULL
+        override val bitrate: Int = 1_000_000
+        override val hwMtu: Int = RnsConstants.MTU
+
+        override var tunnelId: ByteArray? = null
+        override var wantsTunnel: Boolean = false
+
+        override fun send(data: ByteArray) {
+            sent.add(data.copyOf())
+        }
+    }
+
+    private lateinit var iface: CapturingInterface
+    private lateinit var routerIdentity: Identity
+    private lateinit var router: LXMRouter
+
+    private val pathRequestDestHash: ByteArray =
+        Destination.create(
+            identity = null,
+            direction = DestinationDirection.IN,
+            type = DestinationType.PLAIN,
+            appName = "rnstransport",
+            aspects = arrayOf("path", "request"),
+        ).hash
+
+    @BeforeEach
+    fun setup() {
+        try {
+            Transport.stop()
+        } catch (_: Exception) {
+            // Best-effort.
+        }
+        Transport.pathTable.clear()
+        Transport.start(Identity.create(), enableTransport = false)
+        iface = CapturingInterface(name = "capture-${System.nanoTime()}")
+        Transport.registerInterface(iface)
+
+        routerIdentity = Identity.create()
+        router = LXMRouter(identity = routerIdentity)
+    }
+
+    @AfterEach
+    fun teardown() {
+        router.close()
+        try {
+            Transport.deregisterInterface(iface)
+        } catch (_: Exception) {
+            // Best-effort.
+        }
+        Transport.pathTable.clear()
+        try {
+            Transport.stop()
+        } catch (_: Exception) {
+            // Best-effort.
+        }
+    }
+
+    private fun livePathEntry(receivingIfaceHash: ByteArray): PathEntry {
+        val now = System.currentTimeMillis()
+        return PathEntry(
+            timestamp = now,
+            nextHop = ByteArray(RnsConstants.TRUNCATED_HASH_BYTES) { 0xDD.toByte() },
+            hops = 1,
+            expires = now + 3_600_000L,
+            randomBlobs = mutableListOf(),
+            receivingInterfaceHash = receivingIfaceHash,
+            announcePacketHash = ByteArray(RnsConstants.TRUNCATED_HASH_BYTES) { 0xCC.toByte() },
+            state = PathState.ACTIVE,
+            failureCount = 0,
+        )
+    }
+
+    private fun directMessage(destIdentity: Identity): Pair<LXMessage, Destination> {
+        val source = Destination.create(
+            identity = routerIdentity,
+            direction = DestinationDirection.IN,
+            type = DestinationType.SINGLE,
+            appName = "lxmf",
+            aspects = arrayOf("delivery"),
+        )
+        val dest = Destination.create(
+            identity = destIdentity,
+            direction = DestinationDirection.OUT,
+            type = DestinationType.SINGLE,
+            appName = "lxmf",
+            aspects = arrayOf("delivery"),
+        )
+        val message = LXMessage.create(
+            destination = dest,
+            source = source,
+            content = "columba1004",
+            title = "t",
+            desiredMethod = DeliveryMethod.DIRECT,
+        )
+        return message to dest
+    }
+
+    /**
+     * Number of distinct path requests (by request tag) for [destHash]. Counts
+     * logical `Transport.requestPath` calls, not wire packets: each call mints a
+     * unique 16-byte tag, and a single call can broadcast the same packet more
+     * than once (e.g. transport-mode `outbound` emits a locally-originated path
+     * request twice on an interface) — distinct tags collapse those back to one.
+     */
+    private fun pathRequestCountFor(destHash: ByteArray): Int =
+        iface.sent.mapNotNull { wire ->
+            val pkt = Packet.unpack(wire) ?: return@mapNotNull null
+            val isPathReqForDest = pkt.destinationHash.contentEquals(pathRequestDestHash) &&
+                pkt.data.size >= 2 * RnsConstants.TRUNCATED_HASH_BYTES &&
+                pkt.data.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(destHash)
+            if (!isPathReqForDest) {
+                null
+            } else {
+                // tag = trailing 16 bytes of the path-request payload.
+                pkt.data.copyOfRange(pkt.data.size - RnsConstants.TRUNCATED_HASH_BYTES, pkt.data.size)
+                    .joinToString("") { "%02x".format(it) }
+            }
+        }.toSet().size
+
+    private fun linkRequestCount(): Int =
+        iface.sent.count { wire -> Packet.unpack(wire)?.packetType == PacketType.LINKREQUEST }
+
+    @Test
+    @DisplayName("direct send with no path emits exactly one path request and no link request")
+    fun noPathEmitsPathRequest() = runBlocking {
+        val (message, dest) = directMessage(Identity.create())
+        // No path seeded — hasPath is false.
+        router.handleOutbound(message)
+
+        // Drive a few ticks; once the no-link branch sets nextDeliveryAttempt
+        // into the future, further ticks are no-ops, so the count is stable.
+        withTimeout(5_000) {
+            while (pathRequestCountFor(dest.hash) == 0) {
+                router.processOutbound()
+                delay(20)
+            }
+        }
+        repeat(3) { router.processOutbound(); delay(20) }
+
+        // Pre-fix: 0 path requests, 1 link request (blind link attempt).
+        assertEquals(1, pathRequestCountFor(dest.hash), "exactly one path request")
+        assertEquals(0, linkRequestCount(), "no link request without a path")
+        assertEquals(0.01, message.progress, 1e-9)
+    }
+
+    @Test
+    @DisplayName("direct send with a seeded path emits a link request and no path request")
+    fun seededPathEmitsLinkRequest() = runBlocking {
+        val (message, dest) = directMessage(Identity.create())
+        Transport.pathTable[dest.hash.toKey()] = livePathEntry(iface.hash)
+
+        router.handleOutbound(message)
+
+        withTimeout(5_000) {
+            while (linkRequestCount() == 0) {
+                router.processOutbound()
+                delay(20)
+            }
+        }
+        repeat(3) { router.processOutbound(); delay(20) }
+
+        assertEquals(0, pathRequestCountFor(dest.hash), "no path request when a path is known")
+        assertEquals(1, linkRequestCount(), "exactly one link request")
+        assertEquals(0.03, message.progress, 1e-9)
+    }
+
+    @Test
+    @DisplayName("pathless direct retries re-request the path each attempt until FAILED")
+    fun pathlessRetriesUntilMax() = runBlocking {
+        val (message, dest) = directMessage(Identity.create())
+        var failedCount = 0
+        message.failedCallback = { failedCount++ }
+
+        router.handleOutbound(message)
+
+        // Each increment of deliveryAttempts to [1, MAX-1] issues exactly one
+        // path request; the count is independent of tick timing. Force each
+        // attempt due so we don't sleep out PATH_REQUEST_WAIT/DELIVERY_RETRY_WAIT.
+        withTimeout(15_000) {
+            while (message.state != MessageState.FAILED) {
+                message.nextDeliveryAttempt = 0L
+                router.processOutbound()
+                delay(15)
+            }
+        }
+
+        assertEquals(
+            LXMRouter.MAX_DELIVERY_ATTEMPTS - 1,
+            pathRequestCountFor(dest.hash),
+            "one path request per pathless attempt below MAX",
+        )
+        assertEquals(1, failedCount, "failedCallback invoked exactly once")
+    }
+
+    @Test
+    @DisplayName("a closed link that never activated re-requests the path once in transport mode")
+    fun closedNeverActivatedReRequestsOnce() = runBlocking {
+        // Transport-enabled mode: reticulum-kt's Transport.deregisterLink stale-path
+        // recovery is gated to non-transport nodes (Python Transport.py:504 parity),
+        // so here the LXMF closedCallback is the SOLE source of the close-time path
+        // re-request — exactly the columba#1004 transport-mode scenario. (In
+        // non-transport mode both fire, matching Python's jobloop + LXMRouter pair.)
+        Transport.stop()
+        Transport.pathTable.clear()
+        Transport.start(Identity.create(), enableTransport = true)
+        Transport.registerInterface(iface)
+
+        val (message, dest) = directMessage(Identity.create())
+        val hex = dest.hash.toHexString()
+        // Seed a path so the no-link branch establishes a link (rather than
+        // requesting a path) — we want a real link to drive into CLOSED.
+        Transport.pathTable[dest.hash.toKey()] = livePathEntry(iface.hash)
+
+        router.handleOutbound(message)
+        withTimeout(5_000) {
+            while (router.directLinkForTest(hex) == null) {
+                router.processOutbound()
+                delay(20)
+            }
+        }
+        val link = router.directLinkForTest(hex)!!
+        iface.sent.clear() // drop the link request; isolate the close-time path request
+        assertEquals(0, pathRequestCountFor(dest.hash))
+
+        // Link never activated (still PENDING). Closing it fires the
+        // closedCallback synchronously, which re-requests the path once.
+        // Link never activated (still PENDING). Closing it fires the
+        // closedCallback synchronously, which re-requests the path once. In
+        // transport mode reticulum-kt's deregisterLink recovery is gated off, so
+        // the closedCallback is the only source: exactly one logical request.
+        link.teardown(LinkConstants.TEARDOWN_REASON_TIMEOUT)
+
+        assertEquals(1, pathRequestCountFor(dest.hash), "exactly one re-request on close (transport mode)")
+        assertTrue(message.pathRequestRetried, "never-activated retry flag set")
+    }
+}

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/DirectDeliveryPathRequestTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/DirectDeliveryPathRequestTest.kt
@@ -282,8 +282,6 @@ class DirectDeliveryPathRequestTest {
         assertEquals(0, pathRequestCountFor(dest.hash))
 
         // Link never activated (still PENDING). Closing it fires the
-        // closedCallback synchronously, which re-requests the path once.
-        // Link never activated (still PENDING). Closing it fires the
         // closedCallback synchronously, which re-requests the path once. In
         // transport mode reticulum-kt's deregisterLink recovery is gated off, so
         // the closedCallback is the only source: exactly one logical request.

--- a/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
+++ b/lxmf-core/src/test/kotlin/network/reticulum/lxmf/LXMRouterTest.kt
@@ -410,6 +410,12 @@ class LXMRouterTest {
             while (message.state != MessageState.FAILED &&
                 message.state != MessageState.DELIVERED
             ) {
+                // Post-fix, the no-link branch defers failure to the next *due*
+                // tick (Python parity: bump to MAX+1, set nextDeliveryAttempt =
+                // +DELIVERY_RETRY_WAIT, then the next tick's top-of-function check
+                // fails it) instead of failing inline. Force each tick due so the
+                // message isn't gated behind the retry-wait for the whole timeout.
+                message.nextDeliveryAttempt = 0L
                 delay(50)
                 router.processOutbound()
             }

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -56,3 +56,21 @@ Writers in this port: `LXMRouter.processOpportunisticDelivery` (LXMRouter.kt:739
 Readers: any consumer polling progress for UI display, plus `:conformance-bridge`'s `cmdLxmfGetMessageProgress` (Main.kt:740), which is what surfaced this issue in code review.
 
 **Re-evaluation:** Remove `@Volatile` only if `LXMessage` ever migrates to an immutable / coroutine-`StateFlow`-backed progress representation, or if Kotlin gains a portable concurrency annotation that subsumes JVM-`@Volatile` semantics across all targets (Native, JS) the lib might one day support.
+
+### DIRECT-link CLOSED-branch path re-request relocated to the link `closedCallback` — `lxmf-core/src/main/kotlin/network/reticulum/lxmf/LXMRouter.kt::establishLinkForMessage` (closedCallback) and `::processDirectDelivery` (CLOSED branch)
+
+**Python reference:** `LXMF/LXMF/LXMRouter.py:2610-2629` — inside `process_outbound`'s per-message loop, when a message's DIRECT delivery link is `CLOSED`, Python re-requests the path (`RNS.Transport.request_path`), distinguishing "was active, closed unexpectedly" (`direct_link.activated_at != None`) from "never activated" (re-request once, guarded by the dynamic `path_request_retried` attribute), then pops both `direct_links` and `backchannel_links` and reschedules.
+
+**Category:** language/runtime forced
+
+**Date:** 2026-06-10
+
+**Tracking:** columba#1004 (D2). See also `columba` memory `issue-1004-path-requests-direct-delivery`.
+
+**Description:** Python's `direct_links` retains a CLOSED link until the next `process_outbound` tick observes it and runs the per-message CLOSED branch. The kotlin port is event-driven: `establishLinkForMessage` creates the `RNS.Link` with a `closedCallback` that fires the instant the link closes (Link watchdog establishment-timeout or unexpected teardown) and **eagerly removes** the link from `directLinks`, then calls `triggerProcessing()`. Consequently a CLOSED link is essentially never observed by `processDirectDelivery` — the next tick lands in the no-link branch — so porting Python's re-request into that branch would be dead code.
+
+The re-request is therefore relocated to the `closedCallback`, where kotlin actually handles link close. It replicates Python's logic faithfully: `closedLink.activatedAt > 0` ⇒ re-request (was active); else re-request once gated by `LXMessage.pathRequestRetried` (never activated). It is additionally gated on the initiating message still needing delivery (`state == OUTBOUND || SENDING`) to reproduce the fact that Python's CLOSED branch only runs for a message still in the outbound loop — without this, a normal post-delivery close would emit a spurious path request that Python never makes. `processDirectDelivery`'s CLOSED branch is retained as a no-op-ish safety net (clear both link maps + reschedule) for the close-callback race window, but performs no re-request to avoid double-firing.
+
+This matters specifically for transport-enabled nodes: reticulum-kt's `Transport.deregisterLink` stale-path recovery (expire + re-request on pending-link timeout) is intentionally gated to non-transport nodes (Python `Transport.py:504` parity), so for transport-mode users the LXMF close-time re-request is the only mechanism that refreshes a stale path after a failed DIRECT link.
+
+**Re-evaluation:** If the kotlin `LXMRouter` ever stops eagerly removing the link in `closedCallback` and instead lets `processDirectDelivery` observe and pop CLOSED links (matching Python's `direct_links` lifecycle), move the re-request back into the CLOSED branch and delete this deviation. The per-message `pathRequestRetried` semantics would then align 1:1 with Python without the close-event approximation.


### PR DESCRIPTION
Fixes the **LXMF-kt half** of columba#1004 (DIRECT delivery never requests a path, so links can't reach destinations silent since the app opened, and the second checkmark never arrives).

## What
- **No-link branch requests a path first** (`LXMF/LXMRouter.py:2633-2652`): `processDirectDelivery` now does `hasPath ? establish : requestPath + PATH_REQUEST_WAIT`, with the strict `< MAX` attempt gate. Previously it called `establishLinkForMessage` unconditionally — blindly attempting a link that could never establish for a pathless destination, then falling back to PROPAGATED (single ✓).
- **Re-request the path when a DIRECT link closes** (`LXMRouter.py:2610-2622`): relocated to the link `closedCallback`, because kt's link lifecycle is event-driven — the callback removes the link from `directLinks` on close, pre-empting `processDirectDelivery`'s CLOSED branch. Gated on the message still needing delivery; faithfully replicates Python's `activated_at` / `path_request_retried` logic. This specifically restores recovery for **transport-enabled nodes**, where reticulum-kt's `deregisterLink` recovery is intentionally gated off (Python parity). Documented in `port-deviations.md`.
- Added transient `LXMessage.pathRequestRetried` (unpacked). The CLOSED branch now also pops `backchannelLinks`, which it leaked.

## Tests
- 4 new unit tests (`DirectDeliveryPathRequestTest`), **all red on the pre-fix logic** (verified). They count distinct path-request *tags* so transport-mode's double-broadcast of a locally-originated request doesn't skew counts.
- Updated one existing `LXMRouterTest` to drive ticks past the now-Python-faithful *deferred* failure (bump to MAX+1, fail on the next due tick — matching Python's gate, not the old inline immediate-fail).
- Full `lxmf-core` unit suite green; existing DIRECT interop regression green.

## ⚠️ Dependency / stacking
Builds on the reticulum-kt half of columba#1004 (`Link.activatedAt`, unconditional `requestPath`, honest `hasPath`), which is **already merged into reticulum-kt `main`** (rode in via reticulum-kt#80).

**The three `rns-core`/`rns-interfaces`/`rns-test` pins here are a local dev placeholder (`0.0.22-1004dev`), so CI will be red until reticulum-kt main is tagged** (e.g. `v0.0.22`) and the pins in `lxmf-core/build.gradle.kts` are bumped to it (see the TODO there).

Verified end-to-end on-device (two Android emulators + an `rnsd` transport hub): DIRECT delivery to a silent destination now path-requests → links → delivers with proof (✓✓).

---
Authored with assistance from `claude-opus-4-8` (Claude Code), on behalf of the repo owner (torlando-tech).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
